### PR TITLE
Add final tests for Client.

### DIFF
--- a/__tests__/UrqlClient_test.re
+++ b/__tests__/UrqlClient_test.re
@@ -96,7 +96,7 @@ describe("UrqlClient", () => {
     let initialCache = Js.Dict.empty();
     Js.Dict.set(
       initialCache,
-      "12345",
+      "VmeRTX7j-",
       "{ name: Dixie, likes: 1000, breed: Pit Bull }",
     );
 
@@ -148,6 +148,31 @@ describe("UrqlClient", () => {
              "update",
            |])
       );
+    });
+
+    test("should expose a method to convert a cache from Js.t to record", () => {
+      let cache = Client.cacheFromJs(TestUtils.testCacheJs);
+
+      Expect.(expect(cache) |> toEqual(TestUtils.testCache));
+    });
+
+    test("should use an initialCache if provided", () => {
+      let initialCache = Js.Dict.empty();
+      Js.Dict.set(
+        initialCache,
+        "VmeRTX7j-",
+        "{ name: Dixie, likes: 1000, breed: Pit Bull }",
+      );
+
+      let client =
+        Client.make(
+          ~url="https://localhost:3000",
+          ~cache=TestUtils.testCache,
+          ~initialCache,
+          (),
+        );
+
+      Expect.(expect(client) |> toMatchSnapshot);
     });
   });
 });

--- a/__tests__/UrqlConnect_test.re
+++ b/__tests__/UrqlConnect_test.re
@@ -36,7 +36,7 @@ describe("Connect", () => {
     test(
       "should convert the supplied urql data to our variant constructors", () =>
       Expect.(
-        expect(urqlData |> Connect.urqlDataToVariant)
+        expect(Connect.urqlDataToVariant(urqlData))
         |> toEqual(
              Js.Obj.assign(
                urqlData,

--- a/__tests__/__snapshots__/UrqlClient_test.bs.js.snap
+++ b/__tests__/__snapshots__/UrqlClient_test.bs.js.snap
@@ -23,6 +23,31 @@ Client {
 }
 `;
 
+exports[`UrqlClient Client with cache provided should use an initialCache if provided 1`] = `
+Client {
+  "cache": Object {
+    "invalidate": [Function],
+    "invalidateAll": [Function],
+    "read": [Function],
+    "update": [Function],
+    "write": [Function],
+  },
+  "executeMutation": [Function],
+  "executeQuery": [Function],
+  "fetchOptions": Object {
+    "integrity": "",
+    "referrerPolicy": "",
+  },
+  "refreshAllFromCache": [Function],
+  "store": Object {
+    "VmeRTX7j-": "{ name: Dixie, likes: 1000, breed: Pit Bull }",
+  },
+  "subscriptions": Object {},
+  "updateSubscribers": [Function],
+  "url": "https://localhost:3000",
+}
+`;
+
 exports[`UrqlClient Client with fetchOptions provided should instantiate a client instance with fetchOptions 1`] = `
 Client {
   "cache": Object {
@@ -67,7 +92,7 @@ Client {
   },
   "refreshAllFromCache": [Function],
   "store": Object {
-    "12345": "{ name: Dixie, likes: 1000, breed: Pit Bull }",
+    "VmeRTX7j-": "{ name: Dixie, likes: 1000, breed: Pit Bull }",
   },
   "subscriptions": Object {},
   "updateSubscribers": [Function],

--- a/__tests__/utils/TestUtils.re
+++ b/__tests__/utils/TestUtils.re
@@ -78,6 +78,14 @@ let testCache: UrqlClient.cache(Js.Dict.t(string), string) = {
   update,
 };
 
+let testCacheJs: UrqlClient.cacheJs(Js.Dict.t(string), string) = {
+  "write": write,
+  "read": read,
+  "invalidate": invalidate,
+  "invalidateAll": invalidateAll,
+  "update": update,
+};
+
 /* Sample data provided by urql's render prop. */
 let urqlData = {
   "loaded": true,
@@ -89,7 +97,7 @@ let urqlData = {
   "cache": {
     "invalidateAll": () =>
       Js.Promise.make((~resolve, ~reject as _) => resolve(. (): 'a)),
-    "invalidate": (~query: option(UrqlQuery.urqlQuery)=?) =>
+    "invalidate": (~query as _: option(UrqlQuery.urqlQuery)=?, ()) =>
       Js.Promise.make((~resolve, ~reject as _) => resolve(. (): 'a)),
     "update":
       (

--- a/src/UrqlConnect.re
+++ b/src/UrqlConnect.re
@@ -28,7 +28,7 @@ type response('data) =
 /* Render prop conversion types. */
 [@bs.deriving jsConverter]
 type cache('store, 'value) = {
-  invalidate: (~query: UrqlQuery.urqlQuery=?) => Js.Promise.t(unit),
+  invalidate: (~query: UrqlQuery.urqlQuery=?, unit) => Js.Promise.t(unit),
   invalidateAll: unit => Js.Promise.t(unit),
   read: (~query: UrqlQuery.urqlQuery) => Js.Promise.t('value),
   update:


### PR DESCRIPTION
This PR adds some final tests to get `Client` coverage up to 💯 🎉! It also ensures that the `invalidate` key on the cache operations passed to `Connect`'s render prop are properly typed. Since `invalidate` takes only a single optional parameter, `query`, it needs a final positional `unit` to indicate that all arguments have been applied even if no `query` is passed in. More details here: http://2ality.com/2017/12/functions-reasonml.html#with-optional-parameters-you-need-at-least-one-positional-parameter