### PR TITLE
#40 Add support for exchanges.

### DIFF
--- a/examples/1-execute-query-mutation/src/Example.re
+++ b/examples/1-execute-query-mutation/src/Example.re
@@ -91,7 +91,7 @@ module Styles = {
       maxHeight(px(200)),
       overflow(`auto),
       minWidth(px(300)),
-      maxWidth(px(500))
+      maxWidth(px(500)),
     ]);
 };
 

--- a/examples/4-exchanges/bsconfig.json
+++ b/examples/4-exchanges/bsconfig.json
@@ -1,0 +1,25 @@
+{
+  "name": "4-exchanges",
+  "reason": {
+    "react-jsx": 2
+  },
+  "sources": [
+    {
+      "dir": "src",
+      "type": "dev"
+    }
+  ],
+  "package-specs": [
+    {
+      "module": "commonjs",
+      "in-source": true
+    }
+  ],
+  "suffix": ".bs.js",
+  "bs-dependencies": ["reason-urql", "wonka", "reason-react", "bs-css"],
+  "refmt": 3,
+  "warnings": {
+    "error": "+5"
+  },
+  "ppx-flags": ["graphql_ppx/ppx"]
+}

--- a/examples/4-exchanges/bsconfig.json
+++ b/examples/4-exchanges/bsconfig.json
@@ -16,7 +16,7 @@
     }
   ],
   "suffix": ".bs.js",
-  "bs-dependencies": ["reason-urql", "wonka", "reason-react", "bs-css"],
+  "bs-dependencies": ["reason-urql", "wonka"],
   "refmt": 3,
   "warnings": {
     "error": "+5"

--- a/examples/4-exchanges/package.json
+++ b/examples/4-exchanges/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "4-exchanges",
+  "version": "0.1.0",
+  "description": "An example of how to use exchanges in reason-urql.",
+  "main": "index.bs.js",
+  "author": "Parker Ziegler <parker.ziegler@formidable.com>",
+  "license": "MIT",
+  "scripts": {
+    "start": "bsb -make-world -w",
+    "clean": "bsb -clean-world",
+    "start:demo": "webpack-dev-server --hot"
+  },
+  "dependencies": {
+    "reason-react": ">=0.3.4",
+    "reason-urql": "file:../../"
+  },
+  "devDependencies": {
+    "bs-platform": "^4.0.18",
+    "graphql_ppx": "^0.2.8",
+    "webpack": "^4.29.6",
+    "webpack-cli": "^3.2.3",
+    "webpack-dev-server": "^3.2.1"
+  }
+}

--- a/examples/4-exchanges/public/index.html
+++ b/examples/4-exchanges/public/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>reason-urql</title>
+    <style type="text/css">
+      body {
+        margin: 0;
+      }
+    </style>
+    <link
+      href="https://fonts.googleapis.com/css?family=Space+Mono"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="/public/index.js"></script>
+  </body>
+</html>

--- a/examples/4-exchanges/src/index.re
+++ b/examples/4-exchanges/src/index.re
@@ -1,9 +1,27 @@
 open ReasonUrql;
 
+/* This is the native debugExchange that ships with `urql`, re-implemented in Reason.
+     Typically, you'd just add Exchanges.debugExchange to the Client's exchange array.
+   */
+let debugExchange: Exchanges.exchange =
+  exchangeInput => {
+    let forward = Exchanges.forwardGet(exchangeInput);
+
+    ops =>
+      ops
+      |> Wonka.tap((. op) =>
+           Js.log2("[Exchange debug]: Incoming operation: ", op)
+         )
+      |> forward
+      |> Wonka.tap((. res) =>
+           Js.log2("[Exchange debug]: Completed operation: ", res)
+         );
+  };
+
 let client =
   Client.make(
     ~url="https://formidadog-ql.now.sh",
-    ~exchanges=[|Exchanges.debugExchange, Exchanges.fetchExchange|],
+    ~exchanges=[|debugExchange, Exchanges.fetchExchange|],
     (),
   );
 
@@ -11,6 +29,7 @@ module GetAllDogs = [%graphql
   {|
   query dogs {
     dogs {
+      key
       name
       breed
       likes
@@ -21,5 +40,39 @@ module GetAllDogs = [%graphql
 
 let queryRequest = Request.createRequest(~query=GetAllDogs.make()##query, ());
 
+module LikeDog = [%graphql
+  {|
+  mutation likeDog($key: ID!) {
+    likeDog(key: $key) {
+      name
+      likes
+    }
+  }
+  |}
+];
+
 Client.executeQuery(~client, ~query=queryRequest)
-|> Wonka.subscribe((. response) => ());
+|> Wonka.subscribe((. response) => {
+     let dogs = response##data##dogs;
+
+     Js_global.setInterval(
+       () => {
+         dogs->Belt.Array.shuffleInPlace;
+
+         let mutation = LikeDog.make(~key=dogs[0]##key, ());
+
+         let mutationRequest =
+           Request.createRequest(
+             ~query=mutation##query,
+             ~variables=mutation##variables,
+             (),
+           );
+
+         Client.executeMutation(~client, ~mutation=mutationRequest)
+         |> Wonka.subscribe((. response) => Js.log(response))
+         |> ignore;
+       },
+       5000,
+     )
+     |> ignore;
+   });

--- a/examples/4-exchanges/src/index.re
+++ b/examples/4-exchanges/src/index.re
@@ -1,0 +1,25 @@
+open ReasonUrql;
+
+let client =
+  Client.make(
+    ~url="https://formidadog-ql.now.sh",
+    ~exchanges=[|Exchanges.debugExchange, Exchanges.fetchExchange|],
+    (),
+  );
+
+module GetAllDogs = [%graphql
+  {|
+  query dogs {
+    dogs {
+      name
+      breed
+      likes
+    }
+  }
+|}
+];
+
+let queryRequest = Request.createRequest(~query=GetAllDogs.make()##query, ());
+
+Client.executeQuery(~client, ~query=queryRequest)
+|> Wonka.subscribe((. response) => ());

--- a/examples/4-exchanges/webpack.config.js
+++ b/examples/4-exchanges/webpack.config.js
@@ -1,0 +1,15 @@
+const path = require("path");
+
+module.exports = {
+  entry: path.join(__dirname, "src/index.bs.js"),
+  mode: "development",
+  output: {
+    path: path.resolve(__dirname, "build"),
+    publicPath: "/public/",
+    filename: "index.js"
+  },
+  devServer: {
+    open: true,
+    contentBase: path.resolve(__dirname, "public")
+  }
+};

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "workspaces": [
     "1-execute-query-mutation",
-    "2-mutation"
+    "2-mutation",
+    "4-exchanges"
   ]
 }

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -361,6 +361,11 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
+
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
@@ -966,6 +971,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -1025,6 +1035,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-react-context@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
+  integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -1306,6 +1324,13 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -1555,6 +1580,19 @@ faye-websocket@~0.11.1:
   integrity sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=
   dependencies:
     websocket-driver ">=0.5.1"
+
+fbjs@^0.8.0:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -1810,6 +1848,13 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
+graphql@^14.1.1:
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.2.1.tgz#779529bf9a01e7207b977a54c20670b48ca6e95c"
+  integrity sha512-2PL1UbvKeSjy/lUeJqHk+eR9CvuErXoCNwJI4jm3oNFEeY+9ELqHNKO1ZuSxAkasPkpWbmT/iMRMFxd3cEL3tQ==
+  dependencies:
+    iterall "^1.2.2"
+
 graphql_ppx@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/graphql_ppx/-/graphql_ppx-0.2.8.tgz#2f057a69b3131b95cf4cd9ce1e53eb722e6d8baa"
@@ -1817,6 +1862,11 @@ graphql_ppx@^0.2.8:
   dependencies:
     request "^2.82.0"
     yargs "^11.0.0"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
 
 handle-thing@^2.0.0:
   version "2.0.0"
@@ -1984,7 +2034,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.4.4:
+iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -2244,7 +2294,7 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -2286,10 +2336,23 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
+iterall@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
+  integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
@@ -2439,7 +2502,7 @@ loglevel@^1.4.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
   integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -2753,6 +2816,14 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -3204,6 +3275,13 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+  dependencies:
+    asap "~2.0.3"
+
 prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
@@ -3416,6 +3494,8 @@ reason-react@>=0.3.4:
   version "0.1.1"
   dependencies:
     bs-fetch "^0.3.0"
+    graphql "^14.1.1"
+    urql "^1.0.4"
     wonka "^2.0.1"
 
 regex-not@^1.0.0, regex-not@^1.0.2:
@@ -3669,7 +3749,7 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4:
+setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -4130,6 +4210,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+ua-parser-js@^0.7.18:
+  version "0.7.19"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
+  integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
+
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -4199,6 +4284,14 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+urql@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-1.0.4.tgz#e4140a15fbb7571d73a0008e736782522fd704c1"
+  integrity sha512-0/d09NkxvToMx1SVavouNrhPnm/y6k/QXaIpfMCo6/o0YeaOsOxv5xsSf8Pm35v5CLrd7L0sk28ZylnJ8XROeg==
+  dependencies:
+    create-react-context "^0.2.3"
+    wonka "^2.0.1"
 
 use@^3.1.0:
   version "3.1.1"
@@ -4397,6 +4490,11 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
   integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
+
+whatwg-fetch@>=0.10.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 which-module@^2.0.0:
   version "2.0.0"

--- a/package.json
+++ b/package.json
@@ -22,24 +22,21 @@
   "license": "MIT",
   "dependencies": {
     "bs-fetch": "^0.3.0",
-    "wonka": "^2.0.1"
+    "graphql": "^14.1.1",
+    "wonka": "^2.0.1",
+    "urql": "^1.0.4"
   },
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.8",
     "all-contributors-cli": "^5.4.0",
     "bs-platform": "^4.0.18",
-    "codecov": "^3.3.0",
-    "coveralls": "^3.0.2",
-    "graphql": "^14.1.1",
+    "codecov": "3.2.0",
     "graphql_ppx": "^0.2.7",
-    "reason-react": ">=0.3.4",
-    "urql": "^1.0.0"
+    "reason-react": ">=0.3.4"
   },
   "peerDependencies": {
-    "graphql": "^14.1.1",
     "graphql_ppx": "^0.2.7",
-    "reason-react": ">=0.3.4",
-    "urql": "^1.0.0"
+    "reason-react": ">=0.3.4"
   },
   "jest": {
     "testMatch": [

--- a/src/ReasonUrql.re
+++ b/src/ReasonUrql.re
@@ -11,3 +11,5 @@ module Types = UrqlTypes;
 module Request = UrqlRequest;
 
 module Error = UrqlCombinedError;
+
+module Exchanges = UrqlClient.UrqlExchanges;

--- a/src/UrqlClient.re
+++ b/src/UrqlClient.re
@@ -64,6 +64,9 @@ module UrqlExchanges = {
   [@bs.module "urql"] external fallbackExchangeIO: exchangeIO = "";
   [@bs.module "urql"] external fetchExchange: exchange = "";
   [@bs.module "urql"] external subscriptionExchange: exchange = "";
+  [@bs.module "urql"]
+  external composeExchanges: array(exchange) => exchange = "";
+  [@bs.module "urql"] external defaultExchanges: array(exchange) = "";
 };
 
 [@bs.deriving abstract]

--- a/src/UrqlClient.re
+++ b/src/UrqlClient.re
@@ -9,11 +9,70 @@ let unwrapFetchOptions = fetchOptions =>
   | FetchFn(fn) => fn()
   };
 
+module UrqlExchanges = {
+  [@bs.deriving jsConverter]
+  type operationType = [
+    | [@bs.as "subscription"] `Subscription
+    | [@bs.as "query"] `Query
+    | [@bs.as "mutation"] `Mutation
+    | [@bs.as "teardown"] `Teardown
+  ];
+
+  [@bs.deriving abstract]
+  type operationContext = {
+    [@bs.optional]
+    fetchOptions: Fetch.requestInit,
+    requestPolicy: UrqlTypes.requestPolicy,
+    url: string,
+  };
+
+  [@bs.deriving abstract]
+  type operation = {
+    [@bs.optional]
+    variables: Js.Json.t,
+    key: int,
+    query: string,
+    operationName: operationType,
+    context: operationContext,
+  };
+
+  type operationData;
+
+  [@bs.deriving abstract]
+  type operationResult = {
+    operation,
+    [@bs.optional]
+    data: operationData,
+    [@bs.optional]
+    error: UrqlCombinedError.t,
+  };
+
+  type exchangeIO =
+    Wonka.Types.sourceT(operation) => Wonka.Types.sourceT(operationResult);
+
+  [@bs.deriving abstract]
+  type exchangeInput = {
+    forward: exchangeIO,
+    client: t,
+  };
+
+  type exchange = exchangeInput => exchangeIO;
+
+  [@bs.module "urql"] external cacheExchange: exchange = "";
+  [@bs.module "urql"] external debugExchange: exchange = "";
+  [@bs.module "urql"] external dedupExchange: exchange = "";
+  [@bs.module "urql"] external fallbackExchangeIO: exchangeIO = "";
+  [@bs.module "urql"] external fetchExchange: exchange = "";
+  [@bs.module "urql"] external subscriptionExchange: exchange = "";
+};
+
 [@bs.deriving abstract]
 type clientOptions = {
   url: string,
   [@bs.optional]
   fetchOptions: Fetch.requestInit,
+  [@bs.optional]
+  exchanges: array(UrqlExchanges.exchange),
 };
 
 [@bs.new] [@bs.module "urql"] external client: clientOptions => t = "Client";
@@ -28,13 +87,26 @@ external executeMutation:
   (~client: t, ~mutation: UrqlTypes.graphqlRequest) => Wonka.Types.sourceT('a) =
   "";
 /*
-   `make` is equivalent to urql's `createClient`:
-   https://github.com/FormidableLabs/urql/blob/cedff86c5a22a20fe659390c6ecdfff22110ff9e/src/client.ts#L43.
+   `make` is equivalent to urql's `createClient`.
    We opt to use `make` here to adhere to standards in the Reason community.
  */
 let make =
-    (~url: string, ~fetchOptions=FetchObj(Fetch.RequestInit.make()), ()) => {
+    (
+      ~url,
+      ~fetchOptions=FetchObj(Fetch.RequestInit.make()),
+      ~exchanges=[|
+                   UrqlExchanges.dedupExchange,
+                   UrqlExchanges.cacheExchange,
+                   UrqlExchanges.fetchExchange,
+                 |],
+      (),
+    ) => {
   let options =
-    clientOptions(~url, ~fetchOptions=unwrapFetchOptions(fetchOptions), ());
+    clientOptions(
+      ~url,
+      ~fetchOptions=unwrapFetchOptions(fetchOptions),
+      ~exchanges,
+      (),
+    );
   client(options);
 };

--- a/src/components/UrqlMutation.re
+++ b/src/components/UrqlMutation.re
@@ -1,5 +1,3 @@
-open UrqlTypes;
-
 [@bs.module "urql"]
 external mutationComponent: ReasonReact.reactClass = "Mutation";
 
@@ -16,14 +14,14 @@ type mutationRenderProps('a) = {
   data: option('a),
   error: option(UrqlCombinedError.t),
   executeMutation: Js.Json.t => Js.Promise.t('a),
-  response: response('a),
+  response: UrqlTypes.response('a),
 };
 
 let urqlDataToRecord = (result: mutationRenderPropsJs('a)) => {
   let data = result##data |> Js.Nullable.toOption;
   let error = result##error |> Js.Nullable.toOption;
 
-  let response: response('a) =
+  let response: UrqlTypes.response('a) =
     switch (result##fetching, data, error) {
     | (true, _, _) => Fetching
     | (false, Some(data), _) => Data(data)

--- a/src/components/UrqlQuery.re
+++ b/src/components/UrqlQuery.re
@@ -1,5 +1,3 @@
-open UrqlTypes;
-
 [@bs.module "urql"] external queryComponent: ReasonReact.reactClass = "Query";
 
 type queryRenderPropsJs('a) = {
@@ -15,14 +13,14 @@ type queryRenderProps('a) = {
   data: option('a),
   error: option(UrqlCombinedError.t),
   executeQuery: Js.Json.t => Js.Promise.t('a),
-  response: response('a),
+  response: UrqlTypes.response('a),
 };
 
 let urqlDataToRecord = (result: queryRenderPropsJs('a)) => {
   let data = result##data |> Js.Nullable.toOption;
   let error = result##error |> Js.Nullable.toOption;
 
-  let response: response('a) =
+  let response: UrqlTypes.response('a) =
     switch (result##fetching, data, error) {
     | (true, _, _) => Fetching
     | (false, Some(data), _) => Data(data)
@@ -54,7 +52,7 @@ let make = (~query, ~variables, ~requestPolicy=`CacheFirst, children) =>
       jsProps(
         ~query,
         ~variables,
-        ~requestPolicy=requestPolicyToJs(requestPolicy),
+        ~requestPolicy=UrqlTypes.requestPolicyToJs(requestPolicy),
       ),
     result =>
     children(result->urqlDataToRecord)

--- a/src/utils/UrqlRequest.re
+++ b/src/utils/UrqlRequest.re
@@ -1,6 +1,4 @@
-open UrqlTypes;
-
 [@bs.val] [@bs.module "urql"]
 external createRequest:
-  (~query: string, ~variables: Js.Json.t=?, unit) => graphqlRequest =
+  (~query: string, ~variables: Js.Json.t=?, unit) => UrqlTypes.graphqlRequest =
   "";

--- a/yarn.lock
+++ b/yarn.lock
@@ -785,10 +785,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codecov@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.3.0.tgz#7bf337b3f7b0474606b5c31c56dd9e44e395e15d"
-  integrity sha512-S70c3Eg9SixumOvxaKE/yKUxb9ihu/uebD9iPO2IR73IdP4i6ZzjXEULj3d0HeyWPr0DqBfDkjNBWxURjVO5hw==
+codecov@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.2.0.tgz#4465ee19884528092d8c313e1f9e4bdc7d3065cd"
+  integrity sha512-3NJvNARXxilqnqVfgzDHyVrF4oeVgaYW1c1O6Oi5mn93exE7HTSSFNiYdwojWW6IwrCZABJ8crpNbKoo9aUHQw==
   dependencies:
     argv "^0.0.2"
     ignore-walk "^3.0.1"
@@ -871,18 +871,6 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
-
-coveralls@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.2.tgz#f5a0bcd90ca4e64e088b710fa8dda640aea4884f"
-  integrity sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==
-  dependencies:
-    growl "~> 1.10.0"
-    js-yaml "^3.11.0"
-    lcov-parse "^0.0.10"
-    log-driver "^1.2.7"
-    minimist "^1.2.0"
-    request "^2.85.0"
 
 create-react-context@^0.2.3:
   version "0.2.3"
@@ -1446,11 +1434,6 @@ graphql_ppx@^0.2.7:
   dependencies:
     request "^2.82.0"
     yargs "^11.0.0"
-
-"growl@~> 1.10.0":
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
-  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -2263,14 +2246,6 @@ jest@^24.3.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.11.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
 js-yaml@^3.12.0:
   version "3.12.2"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.2.tgz#ef1d067c5a9d9cb65bd72f285b5d8105c77f14fc"
@@ -2401,11 +2376,6 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-lcov-parse@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
-  integrity sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=
-
 left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
@@ -2459,11 +2429,6 @@ lodash@^4.11.2, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
-log-driver@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
-  integrity sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.4.0"
@@ -3150,7 +3115,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.72.0, request@^2.82.0, request@^2.85.0, request@^2.87.0:
+request@^2.72.0, request@^2.82.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -3739,7 +3704,7 @@ urlgrey@^0.4.4:
   resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
   integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=
 
-urql@^1.0.0:
+urql@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/urql/-/urql-1.0.4.tgz#e4140a15fbb7571d73a0008e736782522fd704c1"
   integrity sha512-0/d09NkxvToMx1SVavouNrhPnm/y6k/QXaIpfMCo6/o0YeaOsOxv5xsSf8Pm35v5CLrd7L0sk28ZylnJ8XROeg==


### PR DESCRIPTION
This PR adds support for exchanges 🎉, addressing #40. The bulk of the work went into typing all of the API surface that underpins exchanges, i.e. `operation`, `operationResult`, `operationType`, `operationContext`, `exchangeInput`, and `exchangeIO`, but that was made much easier by `urql`'s TS defs.

A note on the architecture here – you'll see that `UrqlExchanges` is a `module` defined within `UrqlClient`. There's a reason for this. Exchanges accept `exchangeInput` as their single parameter, which is an object composed of `forward` (a function for forwarding operations to the next exchange) and `client` (the client instance, in this case of type `UrqlClient.t`). Because of this pairing between the types for exchanges and the type `t` of the client, the modules have to be co-located or we get the cyclic dependency of death error.

For example, if `UrqlExchanges` was its own module our dependency graph would look like:

- `UrqlExchanges.exchangeInput` references `UrqlClient.t`.
- `UrqlClient` references `UrqlExchanges.exchange` as part of its config options.
- Cyclic dependency error :rip:

Co-locating _makes sense_ here though, because exchanges are really only used by the client. If other folks have other organizational strategies, I'd love to hear them!