### PR TITLE
Add bindings for subscription exchange.

### DIFF
--- a/__tests__/UrqlClient_test.re
+++ b/__tests__/UrqlClient_test.re
@@ -54,4 +54,17 @@ describe("UrqlClient", () => {
       Expect.(expect(client) |> toMatchSnapshot);
     });
   });
+
+  describe("Client with exchanges provided", () =>
+    it("should instantiate a client with exchanges", () => {
+      let client =
+        Client.make(
+          ~url="https://localhost:3000",
+          ~exchanges=[|Exchanges.debugExchange|],
+          (),
+        );
+
+      Expect.(expect(client) |> toMatchSnapshot);
+    })
+  );
 });

--- a/__tests__/__snapshots__/UrqlClient_test.bs.js.snap
+++ b/__tests__/__snapshots__/UrqlClient_test.bs.js.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`UrqlClient Client with exchanges provided should instantiate a client with exchanges 1`] = `
+Client {
+  "activeOperations": Object {},
+  "createOperationContext": [Function],
+  "createRequestOperation": [Function],
+  "dispatchOperation": [Function],
+  "exchange": [Function],
+  "executeMutation": [Function],
+  "executeQuery": [Function],
+  "executeSubscription": [Function],
+  "fetchOptions": Object {
+    "integrity": "",
+    "referrerPolicy": "",
+  },
+  "operations$": [Function],
+  "reexecuteOperation": [Function],
+  "results$": [Function],
+  "url": "https://localhost:3000",
+}
+`;
+
 exports[`UrqlClient Client with fetchOptions provided should instantiate a client instance with fetchOptions provided as FetchFn 1`] = `
 Client {
   "activeOperations": Object {},

--- a/src/UrqlClient.re
+++ b/src/UrqlClient.re
@@ -63,10 +63,42 @@ module UrqlExchanges = {
   [@bs.module "urql"] external dedupExchange: exchange = "";
   [@bs.module "urql"] external fallbackExchangeIO: exchangeIO = "";
   [@bs.module "urql"] external fetchExchange: exchange = "";
-  [@bs.module "urql"] external subscriptionExchange: exchange = "";
   [@bs.module "urql"]
   external composeExchanges: array(exchange) => exchange = "";
   [@bs.module "urql"] external defaultExchanges: array(exchange) = "";
+
+  [@bs.deriving abstract]
+  type observerLike('a) = {
+    next: 'a => unit,
+    error: Js.Exn.t => unit,
+    complete: unit => unit,
+  };
+
+  [@bs.deriving abstract]
+  type observableLike('a) = {
+    subscribe: observerLike('a) => {. "unsubscribe": unit => unit},
+  };
+
+  [@bs.deriving abstract]
+  type subscriptionOperation = {
+    query: string,
+    [@bs.optional]
+    variables: Js.Json.t,
+    key: string,
+    context: operationContext,
+  };
+
+  type subscriptionForwarder('a) =
+    subscriptionOperation => observableLike(UrqlTypes.executionResult('a));
+
+  [@bs.deriving abstract]
+  type subscriptionExchangeOpts('a) = {
+    forwardSubscription: subscriptionForwarder('a),
+  };
+
+  [@bs.module "urql"]
+  external subscriptionExchange: subscriptionExchangeOpts('a) => exchange =
+    "";
 };
 
 [@bs.deriving abstract]

--- a/src/UrqlTypes.re
+++ b/src/UrqlTypes.re
@@ -14,6 +14,14 @@ type graphqlRequest = {
   variables: Js.Json.t,
 };
 
+[@bs.deriving abstract]
+type executionResult('a) = {
+  [@bs.optional]
+  errors: array(UrqlCombinedError.graphqlError),
+  [@bs.optional]
+  data: 'a,
+};
+
 type response('a) =
   | Fetching
   | Data('a)

--- a/src/utils/UrqlCombinedError.re
+++ b/src/utils/UrqlCombinedError.re
@@ -34,12 +34,12 @@ type positions = array(int);
 type originalError = Js.Exn.t;
 
 /* Extension fields to add to the formatted error. */
-type extensions('a) = Js.t({..} as 'a);
+type extension;
 
 /* A simple binding to the GraphQL error type exposed by graphql-js. See:
     https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/graphql/error/GraphQLError.d.ts.
    */
-type graphqlError('a) = {
+type graphqlError = {
   .
   "message": Js.Nullable.t(message),
   "locations": Js.Nullable.t(locations),
@@ -48,15 +48,15 @@ type graphqlError('a) = {
   "source": Js.Nullable.t(source),
   "positions": Js.Nullable.t(positions),
   "originalError": Js.Nullable.t(originalError),
-  "extensions": Js.Nullable.t(extensions('a)),
+  "extensions": Js.Nullable.t(Js.Dict.t(extension)),
 };
 
-type combinedError('a, 'b) = {
+type combinedError('a) = {
   .
   "networkError": Js.Nullable.t(Js.Exn.t),
-  "graphqlErrors": Js.Nullable.t(array(graphqlError('a))),
-  "response": Js.Nullable.t('b),
+  "graphqlErrors": Js.Nullable.t(array(graphqlError)),
+  "response": Js.Nullable.t('a),
 };
 
 [@bs.new] [@bs.module "urql"]
-external combinedError: combinedError('a, 'b) => t = "CombinedError";
+external combinedError: combinedError('a) => t = "CombinedError";


### PR DESCRIPTION
This PR adds specific bindings for `subscriptionExchange`. This exchange is a bit more complex than the others, accepting a `SubscriptionForwarder` and doing some transformations to our subscriptions under the hood. While I don't _fully_ understand how this works, I'm mostly following the interfaces outlined [here](https://github.com/FormidableLabs/urql/blob/0dfa8954c46d0b10d298805ffdad9da5c0d231f9/src/exchanges/subscription.ts#L24-L62). @kitten would appreciate your insight here as much as possible. I'll  try to get moving on implementing an example similar to @andyrichardson's to see if these bindings are halfway decent. 