### PR TITLE
#35 Add bindings for Subscription.

### DIFF
--- a/src/ReasonUrql.re
+++ b/src/ReasonUrql.re
@@ -6,6 +6,8 @@ module Query = UrqlQuery;
 
 module Mutation = UrqlMutation;
 
+module Subscription = UrqlSubscription;
+
 module Types = UrqlTypes;
 
 module Request = UrqlRequest;

--- a/src/components/UrqlMutation.re
+++ b/src/components/UrqlMutation.re
@@ -6,14 +6,16 @@ type mutationRenderPropsJs('a) = {
   "fetching": bool,
   "data": Js.Nullable.t('a),
   "error": Js.Nullable.t(UrqlCombinedError.t),
-  "executeMutation": Js.Json.t => Js.Promise.t('a),
+  "executeMutation":
+    Js.Json.t => Js.Promise.t(UrqlClient.UrqlExchanges.operationResult),
 };
 
 type mutationRenderProps('a) = {
   fetching: bool,
   data: option('a),
   error: option(UrqlCombinedError.t),
-  executeMutation: Js.Json.t => Js.Promise.t('a),
+  executeMutation:
+    Js.Json.t => Js.Promise.t(UrqlClient.UrqlExchanges.operationResult),
   response: UrqlTypes.response('a),
 };
 
@@ -38,12 +40,15 @@ let urqlDataToRecord = (result: mutationRenderPropsJs('a)) => {
   };
 };
 
+[@bs.deriving abstract]
+type jsProps = {query: string};
+
 let make =
     (
       ~query: string,
       children: mutationRenderProps('a) => ReasonReact.reactElement,
     ) =>
   ReasonReact.wrapJsForReason(
-    ~reactClass=mutationComponent, ~props={"query": query}, result =>
-    children(result->urqlDataToRecord)
+    ~reactClass=mutationComponent, ~props=jsProps(~query), result =>
+    result |> urqlDataToRecord |> children
   );

--- a/src/components/UrqlQuery.re
+++ b/src/components/UrqlQuery.re
@@ -5,14 +5,16 @@ type queryRenderPropsJs('a) = {
   "fetching": bool,
   "data": Js.Nullable.t('a),
   "error": Js.Nullable.t(UrqlCombinedError.t),
-  "executeQuery": Js.Json.t => Js.Promise.t('a),
+  "executeQuery":
+    Js.Json.t => Js.Promise.t(UrqlClient.UrqlExchanges.operationResult),
 };
 
 type queryRenderProps('a) = {
   fetching: bool,
   data: option('a),
   error: option(UrqlCombinedError.t),
-  executeQuery: Js.Json.t => Js.Promise.t('a),
+  executeQuery:
+    Js.Json.t => Js.Promise.t(UrqlClient.UrqlExchanges.operationResult),
   response: UrqlTypes.response('a),
 };
 
@@ -55,5 +57,5 @@ let make = (~query, ~variables, ~requestPolicy=`CacheFirst, children) =>
         ~requestPolicy=UrqlTypes.requestPolicyToJs(requestPolicy),
       ),
     result =>
-    children(result->urqlDataToRecord)
+    result |> urqlDataToRecord |> children
   );

--- a/src/components/UrqlSubscription.re
+++ b/src/components/UrqlSubscription.re
@@ -30,7 +30,8 @@ let urqlDataToRecord = (result: subscriptionRenderPropsJs('a)) => {
   {fetching: result##fetching, data, error, response};
 };
 
-type handler('a, 'b) = ('a, 'b) => 'a;
+type handler('a, 'b) =
+  (~prevSubscriptions: option('a), ~subscription: 'b) => 'a;
 
 [@bs.deriving abstract]
 type jsProps('a, 'b) = {

--- a/src/components/UrqlSubscription.re
+++ b/src/components/UrqlSubscription.re
@@ -1,0 +1,63 @@
+[@bs.module "urql"]
+external subscriptionComponent: ReasonReact.reactClass = "Subscription";
+
+type subscriptionRenderPropsJs('a) = {
+  .
+  "fetching": bool,
+  "data": Js.Nullable.t('a),
+  "error": Js.Nullable.t(UrqlCombinedError.t),
+};
+
+type subscriptionRenderProps('a) = {
+  fetching: bool,
+  data: option('a),
+  error: option(UrqlCombinedError.t),
+  response: UrqlTypes.response('a),
+};
+
+let urqlDataToRecord = (result: subscriptionRenderPropsJs('a)) => {
+  let data = result##data |> Js.Nullable.toOption;
+  let error = result##error |> Js.Nullable.toOption;
+
+  let response: UrqlTypes.response('a) =
+    switch (result##fetching, data, error) {
+    | (true, _, _) => Fetching
+    | (false, Some(data), _) => Data(data)
+    | (false, _, Some(error)) => Error(error)
+    | (false, None, None) => NotFound
+    };
+
+  {fetching: result##fetching, data, error, response};
+};
+
+type handler('a, 'b) = ('a, 'b) => 'a;
+
+[@bs.deriving abstract]
+type jsProps('a, 'b) = {
+  query: string,
+  [@bs.optional]
+  variables: Js.Json.t,
+  [@bs.optional]
+  handler: handler('a, 'b),
+};
+
+let make =
+    (
+      ~query,
+      ~variables=?,
+      ~handler=?,
+      children: subscriptionRenderProps('a) => ReasonReact.reactElement,
+    ) => {
+  let props =
+    switch (variables, handler) {
+    | (Some(v), Some(h)) => jsProps(~query, ~variables=v, ~handler=h, ())
+    | (Some(v), None) => jsProps(~query, ~variables=v, ())
+    | (None, Some(h)) => jsProps(~query, ~handler=h, ())
+    | (None, None) => jsProps(~query, ())
+    };
+
+  ReasonReact.wrapJsForReason(
+    ~reactClass=subscriptionComponent, ~props, result =>
+    result |> urqlDataToRecord |> children
+  );
+};


### PR DESCRIPTION
This PR adds bindings for the `Subscription` component. These mostly follow the conventions outlined in `Query` and `Mutation`, with a few specifics that occur only on the `Subscription` component in `urql`. A few things to note:

1. The type for `handler` (`type handler('a, 'b) = ('a, 'b) => 'a`). Basically, `handler` receives the previous subscriptions and the current subscription, and returns the same structure as previous subscriptions. So type parameters are a great way to handle this. I may consider making these named arguments as well for clarity if folks agree.
2. The pattern matching in the `make` function of `Subscription`. Basically, we have two optional props, so we pattern match on a tuple of those two props (`variables` and `handler`) to determine which props to pass to `Subscription`. `urql`'s defaults help us out here and make this nicely ergonomic for Reason consumers.

I'm working on an example right now which will come up in a separate PR.