### PR TITLE
Add final methods exposed by UrqlClient.

### DIFF
--- a/__tests__/UrqlClient_test.re
+++ b/__tests__/UrqlClient_test.re
@@ -11,16 +11,32 @@ describe("UrqlClient", () => {
       Expect.(expect(client) |> toMatchSnapshot)
     );
 
-    it("should expose an executeQuery operation", () =>
+    it("should expose an executeQuery method", () =>
       ExpectJs.(expect(Client.executeQuery) |> toBeTruthy)
     );
 
-    it("should expose an executeMutation operation", () =>
+    it("should expose an executeMutation method", () =>
       ExpectJs.(expect(Client.executeMutation) |> toBeTruthy)
     );
 
-    it("should expose an executeSubscription operation", () =>
+    it("should expose an executeSubscription method", () =>
       ExpectJs.(expect(Client.executeSubscription) |> toBeTruthy)
+    );
+
+    it("should expose an executeRequestOperation method", () =>
+      ExpectJs.(expect(Client.executeRequestOperation) |> toBeTruthy)
+    );
+
+    it("should expose an reexecuteOperation method", () =>
+      ExpectJs.(expect(Client.reexecuteOperation) |> toBeTruthy)
+    );
+
+    it("should expose an createRequestOperation method", () =>
+      ExpectJs.(expect(Client.createRequestOperation) |> toBeTruthy)
+    );
+
+    it("should expose an dispatchOperation method", () =>
+      ExpectJs.(expect(Client.dispatchOperation) |> toBeTruthy)
     );
   });
 

--- a/src/UrqlClient.re
+++ b/src/UrqlClient.re
@@ -114,6 +114,53 @@ external executeSubscription:
   ) =>
   Wonka.Types.sourceT('a) =
   "";
+
+[@bs.send]
+external executeRequestOperation:
+  (~client: t, ~operation: UrqlTypes.operation) =>
+  Wonka.Types.sourceT(UrqlTypes.operationResult) =
+  "";
+
+[@bs.send]
+external reexecuteOperation:
+  (~client: t, ~operation: UrqlTypes.operation) => unit =
+  "";
+
+[@bs.send]
+external createRequestOperationJs:
+  (
+    ~client: t,
+    ~operationType: string,
+    ~request: UrqlTypes.graphqlRequest,
+    ~opts: option(UrqlTypes.partialOperationContext)=?,
+    unit
+  ) =>
+  UrqlTypes.operation =
+  "createRequestOperation";
+
+let createRequestOperation =
+    (
+      ~client: t,
+      ~operationType: UrqlTypes.operationType,
+      ~request: UrqlTypes.graphqlRequest,
+      ~opts: option(UrqlTypes.partialOperationContext)=?,
+      (),
+    ) => {
+  let type_ = UrqlTypes.operationTypeToJs(operationType);
+  createRequestOperationJs(
+    ~client,
+    ~operationType=type_,
+    ~request,
+    ~opts,
+    (),
+  );
+};
+
+[@bs.send]
+external dispatchOperation:
+  (~client: t, ~operation: UrqlTypes.operation) => unit =
+  "";
+
 /*
    `make` is equivalent to urql's `createClient`.
    We opt to use `make` here to adhere to standards in the Reason community.


### PR DESCRIPTION
This PR adds a few lingering methods that are exposed on the `urql` client. While we don't expect users to use these very often, it's good to keep the API 💯% compatible w/ `urql`. 