### PR TITLE
Expose all of urql context

### DIFF
--- a/src/ReasonUrql.re
+++ b/src/ReasonUrql.re
@@ -1,6 +1,8 @@
 module Client = UrqlClient;
 
-module Provider = UrqlProvider;
+module Context = UrqlContext;
+module Provider = UrqlContext.Provider;
+module Consumer = UrqlContext.Consumer;
 
 module Query = UrqlQuery;
 

--- a/src/UrqlContext.re
+++ b/src/UrqlContext.re
@@ -1,0 +1,16 @@
+[@bs.module "urql"]
+external context: React.Context.t(UrqlClient.t) = "Context";
+
+module Provider = {
+  [@bs.module "urql"] [@react.component]
+  external make:
+    (~value: UrqlClient.t, ~children: React.element) => React.element =
+    "Provider";
+}
+
+module Consumer = {
+  [@bs.module "urql"] [@react.component]
+  external make:
+    (~children: UrqlClient.t => React.element) => React.element =
+    "Consumer";
+}

--- a/src/UrqlProvider.re
+++ b/src/UrqlProvider.re
@@ -1,4 +1,0 @@
-[@bs.module "urql"] [@react.component]
-external make:
-  (~value: UrqlClient.t, ~children: React.element) => React.element =
-  "Provider";


### PR DESCRIPTION
Hello again! :)
I noticed only the Provider binding from urql was exposed here, whereas in the urql lib it exports Provider, Consumer and Context, so I created binding for those.

Is the intention to have 100% bindings from urql before 1.0?