### PR TITLE
Typed useQuery MVP

### DIFF
--- a/examples/2-query/package.json
+++ b/examples/2-query/package.json
@@ -6,6 +6,7 @@
   "author": "Kara Stubbs <kara.stubbs@formidable.com>",
   "license": "MIT",
   "scripts": {
+    "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
     "start:demo": "webpack-dev-server --hot"

--- a/examples/2-query/src/Monster.re
+++ b/examples/2-query/src/Monster.re
@@ -34,11 +34,9 @@ module GetPokemon = [%graphql
 [@react.component]
 let make = (~pokemon: string) => {
   /* We set up the query here as we need access to the pokemon
-      value passed in from GetAll */
+     value passed in from GetAll */
   let request = GetPokemon.make(~name=pokemon, ());
-  let query = request##query;
-  let variables = request##variables;
-  let ({response}, _executeQuery) = useQuery(~query, ~variables, ());
+  let ({response}, _executeQuery) = useQuery(~request, ());
 
   switch (response) {
   | Data(data) =>

--- a/src/hooks/UrqlUseQuery.re
+++ b/src/hooks/UrqlUseQuery.re
@@ -8,10 +8,12 @@ type useQueryStateJs('a) = {
 [@bs.deriving abstract]
 type useQueryArgs('a) = {
   query: string,
-  [@bs.optional] variables: 'a,
-  [@bs.optional] requestPolicy: UrqlTypes.requestPolicy,
-  [@bs.optional] pause: bool
-}
+  variables: Js.Json.t,
+  [@bs.optional]
+  requestPolicy: UrqlTypes.requestPolicy,
+  [@bs.optional]
+  pause: bool,
+};
 
 type partialOperationContextFn = option(UrqlTypes.partialOperationContext) => unit;
 type useQueryResponseJs('a) = (useQueryStateJs('a), partialOperationContextFn);

--- a/src/hooks/UrqlUseQuery.rei
+++ b/src/hooks/UrqlUseQuery.rei
@@ -1,10 +1,11 @@
-type partialOperationContextFn = option(UrqlTypes.partialOperationContext) => unit;
+type partialOperationContextFn =
+  option(UrqlTypes.partialOperationContext) => unit;
 type useQueryState('a) = {
   fetching: bool,
   data: option('a),
   error: option(UrqlCombinedError.t),
-  response: UrqlTypes.response('a)
-}
+  response: UrqlTypes.response('a),
+};
 type useQueryResponse('a) = (useQueryState('a), partialOperationContextFn);
 
 let useQuery:

--- a/src/hooks/UrqlUseQuery.rei
+++ b/src/hooks/UrqlUseQuery.rei
@@ -7,4 +7,16 @@ type useQueryState('a) = {
 }
 type useQueryResponse('a) = (useQueryState('a), partialOperationContextFn);
 
-let useQuery: (~query: string, ~variables: 'a=?, ~requestPolicy: UrqlTypes.requestPolicy=?, ~pause: bool=?, unit) => useQueryResponse('b)
+let useQuery:
+  (
+    ~request: {
+                .
+                "parse": Js.Json.t => 'response,
+                "query": string,
+                "variables": 'vars,
+              },
+    ~requestPolicy: UrqlTypes.requestPolicy=?,
+    ~pause: bool=?,
+    unit
+  ) =>
+  useQueryResponse('response);

--- a/src/hooks/UrqlUseQuery.rei
+++ b/src/hooks/UrqlUseQuery.rei
@@ -13,7 +13,7 @@ let useQuery:
                 .
                 "parse": Js.Json.t => 'response,
                 "query": string,
-                "variables": 'vars,
+                "variables": Js.Json.t,
               },
     ~requestPolicy: UrqlTypes.requestPolicy=?,
     ~pause: bool=?,


### PR DESCRIPTION
Implementation of https://github.com/FormidableLabs/reason-urql/issues/67 for useQuery.
It seems to work out pretty cleanly for useQuery, my followup PR to useMutation is slightly worse.
Example 2-query builds and seems to work fine after the change.

(It seems like I have a different version of refmt from the normal maintainers of the project, so I did my best to keep the reformatting changes to unrelated code out of the diff to keep it small/readable)

Thoughts?

(Edit: I was thinking, it's probably worth taking a look at the component bindings to see if they could benefit from a similar change, as the use of the graphql parse function here probably introduces some difference in parsing behaviour if it's not being used on the components. I haven't done it yet because I'm mostly interested in using the hooks.)