### PR TITLE
Typed useMutation

### DIFF
--- a/examples/3-mutation/package.json
+++ b/examples/3-mutation/package.json
@@ -6,6 +6,7 @@
   "author": "Parker Ziegler <parker.ziegler@formidable.com>",
   "license": "MIT",
   "scripts": {
+    "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
     "start:demo": "webpack-dev-server --hot"

--- a/src/hooks/UrqlUseMutation.re
+++ b/src/hooks/UrqlUseMutation.re
@@ -1,8 +1,8 @@
 [@bs.deriving abstract]
-type useMutationResponseJs('a) = {
+type useMutationResponseJs = {
   fetching: bool,
   [@bs.optional]
-  data: 'a,
+  data: Js.Json.t,
   [@bs.optional]
   error: UrqlCombinedError.t,
 };
@@ -18,23 +18,18 @@ type executeMutation =
   option(Js.Json.t) => Js.Promise.t(UrqlTypes.operationResult);
 
 [@bs.module "urql"]
-external useMutationJs:
-  (~query: string) => (useMutationResponseJs('a), executeMutation) =
+external useMutationJs: string => (useMutationResponseJs, executeMutation) =
   "useMutation";
 
 let useMutationResponseToRecord =
-    (parse: Js.Json.t => 'response, result: useMutationResponseJs('a)) => {
-  let data =
-    switch (result->dataGet) {
-    | None => None
-    | Some(d) => Some(parse(d))
-    };
+    (parse: Js.Json.t => 'response, result: useMutationResponseJs) => {
+  let data = result->dataGet->Belt.Option.map(parse);
   let error = result->errorGet;
   let fetching = result->fetchingGet;
 
-  let response: UrqlTypes.response('response) =
+  let response =
     switch (fetching, data, error) {
-    | (true, _, _) => Fetching
+    | (true, _, _) => UrqlTypes.Fetching
     | (false, Some(data), _) => Data(data)
     | (false, _, Some(error)) => Error(error)
     | (false, None, None) => NotFound
@@ -53,7 +48,7 @@ let useMutation =
        },
     ) => {
   let (useMutationResponseJs, executeMutation) =
-    useMutationJs(~query=request##query);
+    useMutationJs(request##query);
   let useMutationResponse =
     useMutationResponseJs |> useMutationResponseToRecord(request##parse);
   (useMutationResponse, () => executeMutation(Some(request##variables)));


### PR DESCRIPTION
The useMutation-counterpart of https://github.com/FormidableLabs/reason-urql/pull/68.

I wanted to see if the easy change for useQuery could work for useMutation as well. For the most part, it was straightforward, but I had to make a second little change to the api because the Module.make() function (the one generated by graphql_ppx that returns the {"query", "variables", "parse"} object) requires the variables to be passed in when you call it rather than as a payload to the executeMutation call.

The downside of this is that it changes the useMutation interface between the component and the hook and it's not the same interface as the js urql. One workaround we could do is passing the makeWithVariables function itself to useMutation so that usage would look like this:
```reason
let (_, executeMutation) = Hooks.useMutation(~make=LikeDog.makeWithVariables);
executeMutation({"key": id});
```

I wasn't sure which design was better so just I went with one of them in the PR.

I noticed that the queries in 3-mutation weren't using graphql_ppx so I converted one of them to use it, and left another as an example of how this api could be used if you didn't want a dependency on graphql_ppx. It's a little worse than before I guess, but not terrible, I thought.