### PR TITLE
Add proper type inference by way of Subscription and SubscriptionWithHandler.

### DIFF
--- a/examples/2-query/src/Monster.re
+++ b/examples/2-query/src/Monster.re
@@ -16,14 +16,14 @@ module GetPokemon = [%graphql
   {|
   query pokemon($name: String!) {
     pokemon(name: $name) {
-        name
-        classification
-        height {
-            maximum
-        }
-        weight {
-            maximum
-        }
+      name
+      classification
+      height {
+        maximum
+      }
+      weight {
+        maximum
+      }
       image
     }
   }

--- a/examples/5-subscription/graphql_schema.json
+++ b/examples/5-subscription/graphql_schema.json
@@ -61,6 +61,30 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "floats",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Float",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -142,6 +166,16 @@
           "possibleTypes": null
         },
         {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point). ",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "Subscription",
           "description": "",
@@ -172,6 +206,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "newFloat",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
                   "ofType": null
                 }
               },

--- a/examples/5-subscription/src/app/App.re
+++ b/examples/5-subscription/src/app/App.re
@@ -7,5 +7,6 @@ let make = () =>
       width="1000"
       style={ReactDOMRe.Style.make(~border="1px solid blue", ())}>
       <Circles />
+      <Squares />
     </svg>
   </div>;

--- a/examples/5-subscription/src/app/Squares.re
+++ b/examples/5-subscription/src/app/Squares.re
@@ -1,0 +1,61 @@
+open ReasonUrql;
+
+module SubscribeRandomFloat = [%graphql
+  {|
+  subscription subscribeFloat {
+    newFloat @bsDecoder(fn: "Js.Float.toString")
+  }
+|}
+];
+
+let handler = (prevSubscriptions, subscription) => {
+  switch (prevSubscriptions) {
+  | Some(subs) => Array.append(subs, [|subscription|])
+  | None => [|subscription|]
+  };
+};
+
+[@bs.scope "Math"] [@bs.val] external random: unit => float = "random";
+[@bs.scope "Math"] [@bs.val] external floor: float => int = "floor";
+[@bs.send] external toString: (int, int) => string = "toString";
+
+let getRandomInt = (max: int) => {
+  floor(random() *. float_of_int(max));
+};
+
+let getRandomHex = () => {
+  let encode = random() *. float_of_int(16777215) |> floor;
+  let hex = encode->toString(16);
+  {j|#$hex|j};
+};
+
+let request = SubscribeRandomFloat.make();
+
+[@react.component]
+let make = () => {
+  <SubscriptionWithHandler request handler>
+    ...{({response}) =>
+      switch (response) {
+      | Fetching => <text> "Loading"->React.string </text>
+      | Data(d) =>
+        Array.mapi(
+          (index, datum) =>
+            <rect
+              x={
+                datum##newFloat;
+              }
+              y={index === 0 ? datum##newFloat : d[index - 1]##newFloat}
+              stroke={getRandomHex()}
+              fill="none"
+              height={getRandomInt(30) |> string_of_int}
+              width={getRandomInt(30) |> string_of_int}
+            />,
+          d,
+        )
+        |> React.array
+      | Error(_e) => <text> "Error"->React.string </text>
+      | NotFound => <text> "Not Found"->React.string </text>
+      }
+    }
+  </SubscriptionWithHandler>;
+};

--- a/examples/5-subscription/src/server/schema.js
+++ b/examples/5-subscription/src/server/schema.js
@@ -5,17 +5,20 @@ const pubsub = new PubSub();
 
 const store = {
   messages: [],
-  numbers: []
+  numbers: [],
+  floats: []
 };
 
 const typeDefs = `
 type Query {
   messages: [Message!]!
   numbers: [Int!]!
+  floats: [Float!]!
 }
 type Subscription {
   newMessage: Message!
   newNumber: Int!
+  newFloat: Float!
 }
 type Message {
   id: ID!,
@@ -26,7 +29,8 @@ type Message {
 const resolvers = {
   Query: {
     messages: store.messages,
-    numbers: store.numbers
+    numbers: store.numbers,
+    floats: store.floats
   },
   Subscription: {
     newMessage: {
@@ -34,6 +38,9 @@ const resolvers = {
     },
     newNumber: {
       subscribe: () => pubsub.asyncIterator("newNumber")
+    },
+    newFloat: {
+      subscribe: () => pubsub.asyncIterator("newFloat")
     }
   }
 };
@@ -71,3 +78,9 @@ setInterval(() => {
     newNumber: getRandomInt(1000)
   });
 }, 2000);
+
+setInterval(() => {
+  pubsub.publish("newFloat", {
+    newFloat: Math.random() * 1000
+  });
+}, 500);

--- a/src/ReasonUrql.re
+++ b/src/ReasonUrql.re
@@ -8,7 +8,9 @@ module Query = UrqlQuery;
 
 module Mutation = UrqlMutation;
 
-module Subscription = UrqlSubscription;
+module Subscription = UrqlSubscription.Subscription;
+
+module SubscriptionWithHandler = UrqlSubscription.SubscriptionWithHandler;
 
 module Types = UrqlTypes;
 
@@ -19,12 +21,13 @@ module Error = UrqlCombinedError;
 module Exchanges = UrqlClient.UrqlExchanges;
 
 module Hooks = {
-  type hookResponse('ret) = Types.hookResponse('ret) = {
-    fetching: bool,
-    data: option('ret),
-    error: option(UrqlCombinedError.t),
-    response: Types.response('ret)
-  };
+  type hookResponse('ret) =
+    Types.hookResponse('ret) = {
+      fetching: bool,
+      data: option('ret),
+      error: option(UrqlCombinedError.t),
+      response: Types.response('ret),
+    };
   include UrqlUseMutation;
   include UrqlUseQuery;
   include UrqlUseSubscription;

--- a/src/UrqlTypes.re
+++ b/src/UrqlTypes.re
@@ -92,18 +92,9 @@ type request('response) = {
   "variables": Js.Json.t,
 };
 
-/* The type of the handler function passed to Subscription and useSubscription.
-   `handler` corresponds to the type of the handler function _before_ the latest subscription has been parsed.
-   `parsedHandler` corresponds to the type of the handler function _after_ the latest subscription has been parsed. */
-type handler('acc) =
-  (~prevSubscriptions: option('acc), ~subscription: Js.Json.t) => 'acc;
-
-type parsedHandler('acc, 'response) =
-  (~prevSubscriptions: option('acc), ~subscription: 'response) => 'acc;
-
 type hookResponse('ret) = {
   fetching: bool,
   data: option('ret),
   error: option(UrqlCombinedError.t),
-  response: response('ret)
-}
+  response: response('ret),
+};


### PR DESCRIPTION
This PR would close #70 and #72 and, in my opinion, should be the feature cap for `v1` 🎉 After @gugahoa's awesome GADT approach for `useSubscription`, I was really excited to port it over to the `Subscription` component. However, as t[his issue demonstrates](https://github.com/reasonml/reason-react/issues/452) (thanks for opening @gugahoa) the `@react.component` PPX has no idea what to do w/ locally abstract types. Bummer.

I don't expect to see a fix for that in the near future, so, in the interest of getting `v1` out, I decided to expand the API surface to include `Subscription` and `SubscriptionWithHandler`. The former will infer `Data(d)` as the parsed result of the subscription, while the latter will infer it as the accumulator `'acc` type inferred through use of the `handler` prop. I hate that we have to increase API surface to get proper type inference, but I also think it's small enough (and likely not used a ton in comparison to the hook) that I can live with it.

I added an example of using `SubscriptionWithHandler` to our subscription example to demonstrate usage. I had to create a new subscription type and resolver on the server since `subscription-transport-ws` has memory leek issues with multiple clients using the same subscription: https://github.com/apollographql/subscriptions-transport-ws/issues/433

But hey, now we have some rad abstract art 😂 

cc/ @Schmavery @gugahoa 