### PR TITLE
Fix ReasonUrql hooks and components interop safety

### DIFF
--- a/src/components/UrqlMutation.re
+++ b/src/components/UrqlMutation.re
@@ -1,8 +1,7 @@
 [@bs.deriving abstract]
 type mutationRenderPropsJs = {
   fetching: bool,
-  [@bs.optional]
-  data: Js.Json.t,
+  data: Js.Nullable.t(Js.Json.t),
   [@bs.optional]
   error: UrqlCombinedError.t,
   executeMutation:
@@ -26,7 +25,7 @@ module MutationJs = {
 };
 
 let urqlDataToRecord = (parse, variables, result) => {
-  let data = result->dataGet->Belt.Option.map(parse);
+  let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
   let error = result->errorGet;
   let fetching = result->fetchingGet;
   let executeMutationFn = result->executeMutationGet;

--- a/src/components/UrqlQuery.re
+++ b/src/components/UrqlQuery.re
@@ -1,8 +1,7 @@
 [@bs.deriving abstract]
 type queryRenderPropsJs = {
   fetching: bool,
-  [@bs.optional]
-  data: Js.Json.t,
+  data: Js.Nullable.t(Js.Json.t),
   [@bs.optional]
   error: UrqlCombinedError.t,
   executeQuery: option(Js.Json.t) => Js.Promise.t(UrqlTypes.operationResult),
@@ -31,7 +30,7 @@ module QueryJs = {
 };
 
 let urqlDataToRecord = (parse, result) => {
-  let data = result->dataGet->Belt.Option.map(parse);
+  let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
   let error = result->errorGet;
   let fetching = result->fetchingGet;
   let executeQuery = result->executeQueryGet;

--- a/src/components/UrqlSubscription.re
+++ b/src/components/UrqlSubscription.re
@@ -3,8 +3,7 @@ open UrqlTypes;
 [@bs.deriving abstract]
 type subscriptionRenderPropsJs('ret) = {
   fetching: bool,
-  [@bs.optional]
-  data: 'ret,
+  data: Js.Nullable.t('ret),
   [@bs.optional]
   error: UrqlCombinedError.t,
 };
@@ -30,7 +29,7 @@ module SubscriptionJs = {
 };
 
 let urqlDataToRecord = (parse, result) => {
-  let data = result->dataGet->Belt.Option.map(parse);
+  let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
   let error = result->errorGet;
   let fetching = result->fetchingGet;
 

--- a/src/hooks/UrqlUseMutation.re
+++ b/src/hooks/UrqlUseMutation.re
@@ -35,10 +35,16 @@ let useMutationResponseToRecord =
 let useMutation = (~request: request('response)) => {
   let (useMutationResponseJs, executeMutationJs) =
     useMutationJs(request##query);
-  let useMutationResponse = React.useMemo1(
-    () => useMutationResponseJs |> useMutationResponseToRecord(request##parse),
-    [|useMutationResponseJs|]
+  let useMutationResponse =
+    React.useMemo2(
+      () =>
+        useMutationResponseJs |> useMutationResponseToRecord(request##parse),
+      (request##parse, useMutationResponseJs),
     );
-  let executeMutation = React.useCallback1(() => executeMutationJs(Some(request##variables)), [|request##variables|]);
+  let executeMutation =
+    React.useCallback1(
+      () => executeMutationJs(Some(request##variables)),
+      [|request##variables|],
+    );
   (useMutationResponse, executeMutation);
 };

--- a/src/hooks/UrqlUseMutation.re
+++ b/src/hooks/UrqlUseMutation.re
@@ -3,8 +3,7 @@ open UrqlTypes;
 [@bs.deriving abstract]
 type useMutationResponseJs = {
   fetching: bool,
-  [@bs.optional]
-  data: Js.Json.t,
+  data: Js.Nullable.t(Js.Json.t),
   [@bs.optional]
   error: UrqlCombinedError.t,
 };
@@ -18,7 +17,7 @@ external useMutationJs: string => (useMutationResponseJs, executeMutation) =
 
 let useMutationResponseToRecord =
     (parse: Js.Json.t => 'response, result: useMutationResponseJs) => {
-  let data = result->dataGet->Belt.Option.map(parse);
+  let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
   let error = result->errorGet;
   let fetching = result->fetchingGet;
 

--- a/src/hooks/UrqlUseMutation.re
+++ b/src/hooks/UrqlUseMutation.re
@@ -34,9 +34,12 @@ let useMutationResponseToRecord =
 };
 
 let useMutation = (~request: request('response)) => {
-  let (useMutationResponseJs, executeMutation) =
+  let (useMutationResponseJs, executeMutationJs) =
     useMutationJs(request##query);
-  let useMutationResponse =
-    useMutationResponseJs |> useMutationResponseToRecord(request##parse);
-  (useMutationResponse, () => executeMutation(Some(request##variables)));
+  let useMutationResponse = React.useMemo1(
+    () => useMutationResponseJs |> useMutationResponseToRecord(request##parse),
+    [|useMutationResponseJs|]
+    );
+  let executeMutation = React.useCallback1(() => executeMutationJs(Some(request##variables)), [|request##variables|]);
+  (useMutationResponse, executeMutation);
 };

--- a/src/hooks/UrqlUseQuery.re
+++ b/src/hooks/UrqlUseQuery.re
@@ -3,8 +3,7 @@ open UrqlTypes;
 [@bs.deriving abstract]
 type useQueryStateJs = {
   fetching: bool,
-  [@bs.optional]
-  data: Js.Json.t,
+  data: Js.Nullable.t(Js.Json.t),
   [@bs.optional]
   error: UrqlCombinedError.t,
 };
@@ -29,7 +28,7 @@ type useQueryResponse('response) = (
 );
 
 let useQueryResponseToRecord = (parse, result) => {
-  let data = result->dataGet->Belt.Option.map(parse);
+  let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
   let error = result->errorGet;
   let fetching = result->fetchingGet;
 

--- a/src/hooks/UrqlUseQuery.re
+++ b/src/hooks/UrqlUseQuery.re
@@ -56,7 +56,11 @@ let useQuery = (~request, ~requestPolicy=?, ~pause=?, ()) => {
       (),
     );
   let (state, executeQuery) = useQueryJs(args);
-  let state_record = state |> useQueryResponseToRecord(request##parse);
+  let state_record =
+    React.useMemo2(
+      () => state |> useQueryResponseToRecord(request##parse),
+      (state, request##parse),
+    );
 
   (state_record, executeQuery);
 };

--- a/src/hooks/UrqlUseSubscription.re
+++ b/src/hooks/UrqlUseSubscription.re
@@ -14,8 +14,7 @@ type useSubscriptionArgs = {
 [@bs.deriving abstract]
 type useSubscriptionResponseJs('ret) = {
   fetching: bool,
-  [@bs.optional]
-  data: 'ret,
+  data: Js.Nullable.t('ret),
   [@bs.optional]
   error: UrqlCombinedError.t,
 };
@@ -27,7 +26,7 @@ external useSubscriptionJs:
   "useSubscription";
 
 let useSubscriptionResponseToRecord = (parse, result) => {
-  let data = result->dataGet->Belt.Option.map(parse);
+  let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
   let error = result->errorGet;
   let fetching = result->fetchingGet;
 

--- a/src/hooks/UrqlUseSubscription.re
+++ b/src/hooks/UrqlUseSubscription.re
@@ -59,18 +59,23 @@ let useSubscription =
       (),
     );
 
-  let state: hookResponse(ret) =
-    switch (handler) {
-    | NoHandler =>
-      useSubscriptionJs(args, None)[0]
-      |> useSubscriptionResponseToRecord(parse)
-    | Handler(handler_fn) =>
-      useSubscriptionJs(
-        args,
-        Some((acc, data) => handler_fn(acc, parse(data))),
-      )[0]
-      |> useSubscriptionResponseToRecord(x => x)
-    };
+  React.useMemo3(
+    () => {
+      let state: hookResponse(ret) =
+        switch (handler) {
+        | NoHandler =>
+          useSubscriptionJs(args, None)[0]
+          |> useSubscriptionResponseToRecord(parse)
+        | Handler(handler_fn) =>
+          useSubscriptionJs(
+            args,
+            Some((acc, data) => handler_fn(acc, parse(data))),
+          )[0]
+          |> useSubscriptionResponseToRecord(x => x)
+        };
 
-  state;
+      state;
+    },
+    (handler, args, parse),
+  );
 };


### PR DESCRIPTION
Since we got closer to 1.0, I have been using reason-urql at my startup, and noticed some unexpected behaviors from the hooks.

## Problem 1
The response from JS urql can contain data that is either `null` or `undefined`, this is not properly covered by `[@bs.optional]`, the fix is to use `Js.Nullable.t('a)`, which can be safely converted to an `option('a)`

## Problem 2
The return value from reason-urql hooks were not safe to use in the dependency list of `useEffect`, `useMemo`, `useCallback` and similar, even though the response JS-land seems safe to use. That's caused by us converting the Js object to an Reason type, and at runtime that always creates a new object