### PR TITLE
Fix executeQuery signature

### DIFF
--- a/src/UrqlClient.re
+++ b/src/UrqlClient.re
@@ -87,7 +87,7 @@ external executeQuery:
   (
     ~client: t,
     ~query: UrqlTypes.graphqlRequest,
-    ~opts: option(UrqlTypes.partialOperationContext)=?,
+    ~opts: UrqlTypes.partialOperationContext=?,
     unit
   ) =>
   Wonka.Types.sourceT('a) =


### PR DESCRIPTION
A signature with `~opts: option(UrqlTypes.partialOperationContext)=?` will expect `opts` of type `option(option(UrqlTypes.partialOperationContext))`, instead of the intended (I believe) `option(UrqlTypes.partialOperationContext)`