### PR TITLE
Type cleanup in UrqlTypes and UrqlClient.

### DIFF
--- a/examples/1-execute-query-mutation/package.json
+++ b/examples/1-execute-query-mutation/package.json
@@ -6,6 +6,7 @@
   "author": "Parker Ziegler <parker.ziegler@formidable.com>",
   "license": "MIT",
   "scripts": {
+    "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
     "start:demo": "webpack-dev-server --hot"
@@ -16,7 +17,7 @@
     "reason-urql": "link:../../"
   },
   "devDependencies": {
-    "bs-platform": "^5.0.3",
+    "bs-platform": "5.0.4",
     "graphql_ppx": "^0.2.8",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3",

--- a/examples/1-execute-query-mutation/src/App.re
+++ b/examples/1-execute-query-mutation/src/App.re
@@ -1,18 +1,16 @@
-module Styles = {
-  open Css;
-
-  let page =
-    style([
-      position(absolute),
-      top(px(0)),
-      bottom(px(0)),
-      left(px(0)),
-      right(px(0)),
-      padding(px(20)),
-    ]);
-};
-
 [@react.component]
 let make = () => {
-  <div className=Styles.page> <ColdStart /> <Previewer /> </div>;
+  <div
+    style={ReactDOMRe.Style.make(
+      ~position="absolute",
+      ~top="0px",
+      ~bottom="0px",
+      ~left="0px",
+      ~right="0px",
+      ~padding="20px",
+      (),
+    )}>
+    <ColdStart />
+    <Previewer />
+  </div>;
 };

--- a/examples/1-execute-query-mutation/src/ColdStart.re
+++ b/examples/1-execute-query-mutation/src/ColdStart.re
@@ -1,16 +1,12 @@
-module Styles = {
-  open Css;
-
-  let coldStart =
-    style([fontFamily("'Space Mono', monospace"), fontSize(rem(1.5))]);
-};
-
-let str = React.string;
-
 [@react.component]
 let make = () => {
-  <h1 className=Styles.coldStart>
+  <h1
+    style={ReactDOMRe.Style.make(
+      ~fontFamily="'Space Mono', monospace",
+      ~fontSize="1.5rem",
+      (),
+    )}>
     "The deployed server is a Now instance booting from a cold start. Wait ~30 seconds after executing your first query to see results. After that, you should see updates instantly!"
-    ->str
+    ->React.string
   </h1>;
 };

--- a/examples/1-execute-query-mutation/src/Previewer.re
+++ b/examples/1-execute-query-mutation/src/Previewer.re
@@ -37,64 +37,6 @@ let mutationRequest =
     (),
   );
 
-module Styles = {
-  open Css;
-
-  let wrapper = style([display(flexBox), padding(px(20))]);
-
-  let side =
-    style([
-      display(flexBox),
-      flexDirection(column),
-      alignItems(center),
-      flexBasis(pct(50.)),
-    ]);
-
-  let section = style([margin(px(10))]);
-
-  let title =
-    style([
-      fontSize(rem(1.5)),
-      fontFamily("Space Mono, 'sans-serif'"),
-      margin(px(5)),
-    ]);
-
-  let button = bdColor =>
-    style([
-      borderColor(hex(bdColor)),
-      color(hex(bdColor)),
-      backgroundColor(white),
-      fontSize(rem(1.2)),
-      margin(px(10)),
-      borderRadius(px(15)),
-      padding(px(10)),
-      cursor(`pointer),
-    ]);
-
-  let code = bgColor =>
-    style([
-      backgroundColor(hex(bgColor)),
-      color(white),
-      padding(px(20)),
-      opacity(0.5),
-      whiteSpace(`pre),
-      fontFamily("Space Mono, 'sans-serif'"),
-      borderRadius(px(5)),
-      maxHeight(px(200)),
-      overflow(`auto),
-      width(vw(30.)),
-    ]);
-
-  type colors = {
-    query: string,
-    mutation: string,
-  };
-
-  let colors = {query: "48a9dc", mutation: "db4d3f"};
-};
-
-let str = React.string;
-
 type state = {
   query: string,
   mutation: string,
@@ -135,46 +77,48 @@ let make = () => {
            SetMutation(Js.Json.stringifyWithSpace(response##data, 2)),
          )
        );
-  <div className=Styles.wrapper>
-    <div className=Styles.side>
-      <section className=Styles.section>
-        <span className=Styles.title> "Query"->str </span>
-        <div className={Styles.colors.query->Styles.code}>
+  <div className=PreviewerStyles.previewer>
+    <div className=PreviewerStyles.side>
+      <section className=PreviewerStyles.section>
+        <span className=PreviewerStyles.title> "Query"->React.string </span>
+        <div className={PreviewerStyles.colors.query->PreviewerStyles.code}>
           {|query dogs {
-            dogs {
-              name
-              breed
-              likes
-            }
-          }|}
-          ->str
+  dogs {
+    name
+    breed
+    likes
+  }
+}|}
+          ->React.string
         </div>
         <button
-          className={Styles.colors.query->Styles.button}
+          className={PreviewerStyles.colors.query->PreviewerStyles.button}
           onClick={_event => executeQuery()}>
-          "Execute Query"->str
+          "Execute Query"->React.string
         </button>
       </section>
       {switch (String.length(state.query)) {
        | 0 => React.null
        | _ =>
-         <section className=Styles.section>
-           <span className=Styles.title> "Result"->str </span>
-           <div className={Styles.colors.query->Styles.code}>
-             state.query->str
+         <section className=PreviewerStyles.section>
+           <span className=PreviewerStyles.title>
+             "Result"->React.string
+           </span>
+           <div className={PreviewerStyles.colors.query->PreviewerStyles.code}>
+             state.query->React.string
            </div>
            <button
-             className={Styles.colors.query->Styles.button}
+             className={PreviewerStyles.colors.query->PreviewerStyles.button}
              onClick={_event => dispatch(ClearQuery)}>
-             "Clear Query"->str
+             "Clear Query"->React.string
            </button>
          </section>
        }}
     </div>
-    <div className=Styles.side>
-      <section className=Styles.section>
-        <span className=Styles.title> "Mutation"->str </span>
-        <div className={"db4d3f"->Styles.code}>
+    <div className=PreviewerStyles.side>
+      <section className=PreviewerStyles.section>
+        <span className=PreviewerStyles.title> "Mutation"->React.string </span>
+        <div className={PreviewerStyles.colors.mutation->PreviewerStyles.code}>
           {|mutation likeDog($key: ID!) {
   likeDog(key: $key) {
     name
@@ -182,24 +126,31 @@ let make = () => {
     likes
   }
 }|}
-          ->str
+          ->React.string
         </div>
         <button
-          className={"db4d3f"->Styles.button}
+          className={PreviewerStyles.colors.mutation->PreviewerStyles.button}
           onClick={_event => executeMutation()}>
-          "Execute Mutation"->str
+          "Execute Mutation"->React.string
         </button>
       </section>
       {switch (String.length(state.mutation)) {
        | 0 => React.null
        | _ =>
-         <section className=Styles.section>
-           <span className=Styles.title> "Result"->str </span>
-           <div className={"db4d3f"->Styles.code}> state.mutation->str </div>
+         <section className=PreviewerStyles.section>
+           <span className=PreviewerStyles.title>
+             "Result"->React.string
+           </span>
+           <div
+             className={PreviewerStyles.colors.mutation->PreviewerStyles.code}>
+             state.mutation->React.string
+           </div>
            <button
-             className={"db4d3f"->Styles.button}
+             className={
+               PreviewerStyles.colors.mutation->PreviewerStyles.button
+             }
              onClick={_event => dispatch(ClearMutation)}>
-             "Clear Mutation"->str
+             "Clear Mutation"->React.string
            </button>
          </section>
        }}

--- a/examples/1-execute-query-mutation/src/PreviewerStyles.re
+++ b/examples/1-execute-query-mutation/src/PreviewerStyles.re
@@ -1,0 +1,53 @@
+open Css;
+
+let previewer = style([display(flexBox), padding(px(20))]);
+
+let side =
+  style([
+    display(flexBox),
+    flexDirection(column),
+    alignItems(center),
+    flexBasis(pct(50.)),
+  ]);
+
+let section = style([margin(px(10))]);
+
+let title =
+  style([
+    fontSize(rem(1.5)),
+    fontFamily("Space Mono, 'sans-serif'"),
+    margin(px(5)),
+  ]);
+
+let button = bdColor =>
+  style([
+    borderColor(hex(bdColor)),
+    color(hex(bdColor)),
+    backgroundColor(white),
+    fontSize(rem(1.2)),
+    margin(px(10)),
+    borderRadius(px(15)),
+    padding(px(10)),
+    cursor(`pointer),
+  ]);
+
+let code = bgColor =>
+  style([
+    backgroundColor(hex(bgColor)),
+    color(white),
+    padding(px(20)),
+    opacity(0.5),
+    whiteSpace(`pre),
+    fontFamily("Space Mono, 'sans-serif'"),
+    borderRadius(px(5)),
+    maxHeight(px(200)),
+    overflow(`auto),
+    width(vw(30.)),
+  ]);
+
+type colors = {
+  query: string,
+  mutation: string,
+};
+
+let colors = {query: "48a9dc", mutation: "db4d3f"};

--- a/examples/1-execute-query-mutation/yarn.lock
+++ b/examples/1-execute-query-mutation/yarn.lock
@@ -646,10 +646,10 @@ bs-fetch@^0.3.0:
   resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.1.tgz#9c7d074b27e6bb2b9f2ec985964f32bcac49f79e"
   integrity sha512-MxwnuuXPldXnoCtlpeN5JNbbmb1tVgsqpLfVunvuMLAIQNyP0TqoImHiQRTz38PBSN8/iX+2yVlm+PFJfnHHiA==
 
-bs-platform@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.3.tgz#2b167603ef52574cb9534fabab702f6013715e6c"
-  integrity sha512-GAeypBebeDGTay5kJ3v5Z3Whp1Q4zQ0hAttflVtPG3zps88xDZnVAlS3JGIIBDmJFEMyNtv5947a/IWKvWXcPw==
+bs-platform@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"
+  integrity sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==
 
 bs-rebel@^0.2.3:
   version "0.2.3"
@@ -4210,7 +4210,7 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urql@^1.0.5:
+urql@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/urql/-/urql-1.1.3.tgz#41fffb0a3b1a3f7ac47be55b7f84ca69875e7358"
   integrity sha512-H6xdtT+b3n7OYG1U/ItLHTBfBpM0Kxd6FkQSYP1TvylqUeyz160whRu/XpwDRt2VwbLy5+j729wv4BF1f1zP4Q==

--- a/examples/2-query/package.json
+++ b/examples/2-query/package.json
@@ -17,7 +17,7 @@
     "reason-urql": "link:../../"
   },
   "devDependencies": {
-    "bs-platform": "^5.0.3",
+    "bs-platform": "5.0.4",
     "graphql_ppx": "^0.2.8",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3",

--- a/examples/2-query/yarn.lock
+++ b/examples/2-query/yarn.lock
@@ -671,7 +671,7 @@ bs-fetch@^0.3.0:
   resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.1.tgz#9c7d074b27e6bb2b9f2ec985964f32bcac49f79e"
   integrity sha512-MxwnuuXPldXnoCtlpeN5JNbbmb1tVgsqpLfVunvuMLAIQNyP0TqoImHiQRTz38PBSN8/iX+2yVlm+PFJfnHHiA==
 
-bs-platform@^5.0.3:
+bs-platform@5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"
   integrity sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==

--- a/examples/3-mutation/package.json
+++ b/examples/3-mutation/package.json
@@ -17,7 +17,7 @@
     "reason-urql": "link:../../"
   },
   "devDependencies": {
-    "bs-platform": "^5.0.4",
+    "bs-platform": "5.0.4",
     "graphql_ppx": "^0.2.8",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3",

--- a/examples/3-mutation/yarn.lock
+++ b/examples/3-mutation/yarn.lock
@@ -646,7 +646,7 @@ bs-fetch@^0.3.0:
   resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.1.tgz#9c7d074b27e6bb2b9f2ec985964f32bcac49f79e"
   integrity sha512-MxwnuuXPldXnoCtlpeN5JNbbmb1tVgsqpLfVunvuMLAIQNyP0TqoImHiQRTz38PBSN8/iX+2yVlm+PFJfnHHiA==
 
-bs-platform@^5.0.4:
+bs-platform@5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"
   integrity sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==

--- a/examples/4-exchanges/bsconfig.json
+++ b/examples/4-exchanges/bsconfig.json
@@ -1,7 +1,7 @@
 {
   "name": "4-exchanges",
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "sources": [
     {

--- a/examples/4-exchanges/package.json
+++ b/examples/4-exchanges/package.json
@@ -6,17 +6,18 @@
   "author": "Parker Ziegler <parker.ziegler@formidable.com>",
   "license": "MIT",
   "scripts": {
+    "build": "bsb -make-world",
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
     "start:demo": "webpack-dev-server --hot"
   },
   "dependencies": {
     "bs-css": "^8.0.4",
-    "reason-react": ">=0.3.4",
+    "reason-react": "0.7.0",
     "reason-urql": "link:../../"
   },
   "devDependencies": {
-    "bs-platform": "^5.0.3",
+    "bs-platform": "5.0.4",
     "graphql_ppx": "^0.2.8",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3",

--- a/examples/4-exchanges/src/Console.re
+++ b/examples/4-exchanges/src/Console.re
@@ -1,44 +1,10 @@
-module Styles = {
-  open Css;
-
-  type colors = {
-    codeBackground: string,
-    codeColor: string,
-  };
-
-  let colors = {codeBackground: "eff7ff", codeColor: "0366d6"};
-
-  let wrapper =
-    style([display(flexBox), height(vh(100.)), width(vw(100.))]);
-
-  let title =
-    style([
-      fontFamily("'Space Mono', monospace"),
-      fontSize(rem(3.)),
-      margin(auto),
-      padding(pct(10.)),
-    ]);
-
-  let code =
-    style([
-      backgroundColor(hex(colors.codeBackground)),
-      color(hex(colors.codeColor)),
-      padding(px(10)),
-    ]);
-};
-
-let str = ReasonReact.string;
-
-let component = ReasonReact.statelessComponent("Console");
-
-let make = _children => {
-  ...component,
-  render: _self =>
-    <div className=Styles.wrapper>
-      <h1 className=Styles.title>
-        "Open your console to see the "->str
-        <code className=Styles.code> "debugExchange"->str </code>
-        " printing operations."->str
-      </h1>
-    </div>,
+[@react.component]
+let make = () => {
+  <div className=ConsoleStyles.console>
+    <h1 className=ConsoleStyles.title>
+      "Open your console to see the "->React.string
+      <code className=ConsoleStyles.code> "debugExchange"->React.string </code>
+      " printing operations."->React.string
+    </h1>
+  </div>;
 };

--- a/examples/4-exchanges/src/ConsoleStyles.re
+++ b/examples/4-exchanges/src/ConsoleStyles.re
@@ -1,0 +1,19 @@
+open Css;
+
+let console =
+  style([display(flexBox), height(vh(100.)), width(vw(100.))]);
+
+let title =
+  style([
+    fontFamily("'Space Mono', monospace"),
+    fontSize(rem(3.)),
+    margin(auto),
+    padding(pct(10.)),
+  ]);
+
+let code =
+  style([
+    backgroundColor(hex("eff7ff")),
+    color(hex("0366d6")),
+    padding(px(10)),
+  ]);

--- a/examples/4-exchanges/yarn.lock
+++ b/examples/4-exchanges/yarn.lock
@@ -368,11 +368,6 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
-
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
@@ -651,10 +646,10 @@ bs-fetch@^0.3.0:
   resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.1.tgz#9c7d074b27e6bb2b9f2ec985964f32bcac49f79e"
   integrity sha512-MxwnuuXPldXnoCtlpeN5JNbbmb1tVgsqpLfVunvuMLAIQNyP0TqoImHiQRTz38PBSN8/iX+2yVlm+PFJfnHHiA==
 
-bs-platform@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.3.tgz#2b167603ef52574cb9534fabab702f6013715e6c"
-  integrity sha512-GAeypBebeDGTay5kJ3v5Z3Whp1Q4zQ0hAttflVtPG3zps88xDZnVAlS3JGIIBDmJFEMyNtv5947a/IWKvWXcPw==
+bs-platform@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"
+  integrity sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==
 
 bs-rebel@^0.2.3:
   version "0.2.3"
@@ -979,11 +974,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -1042,14 +1032,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-create-react-context@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
-  integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
-  dependencies:
-    fbjs "^0.8.0"
-    gud "^1.0.0"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -1324,13 +1306,6 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
-
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -1580,19 +1555,6 @@ faye-websocket@~0.11.1:
   integrity sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=
   dependencies:
     websocket-driver ">=0.5.1"
-
-fbjs@^0.8.0:
-  version "0.8.17"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
-  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
 
 figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -1848,6 +1810,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
+graphql-tag@^2.10.1:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
+  integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
+
 graphql@^14.1.1:
   version "14.2.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.2.1.tgz#779529bf9a01e7207b977a54c20670b48ca6e95c"
@@ -1862,11 +1829,6 @@ graphql_ppx@^0.2.8:
   dependencies:
     request "^2.82.0"
     yargs "^11.0.0"
-
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
-  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
 
 handle-thing@^2.0.0:
   version "2.0.0"
@@ -2034,7 +1996,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -2289,7 +2251,7 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -2330,14 +2292,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -2492,7 +2446,7 @@ loglevel@^1.6.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
   integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -2806,14 +2760,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -3260,14 +3206,7 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
-prop-types@^15.6.2:
+prop-types@^15.6.0, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -3467,7 +3406,7 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-reason-react@>=0.3.4:
+reason-react@0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.7.0.tgz#46a975c321e81cd51310d7b1a02418ca7667b0d6"
   integrity sha512-czR/f0lY5iyLCki9gwftOFF5Zs40l7ZSFmpGK/Z6hx2jBVeFDmIiXB8bAQW/cO6IvtuEt97OmsYueiuOYG9XjQ==
@@ -3740,7 +3679,7 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5:
+setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -4201,11 +4140,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-ua-parser-js@^0.7.18:
-  version "0.7.19"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
-  integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
-
 union-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
@@ -4276,13 +4210,15 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urql@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-1.0.4.tgz#e4140a15fbb7571d73a0008e736782522fd704c1"
-  integrity sha512-0/d09NkxvToMx1SVavouNrhPnm/y6k/QXaIpfMCo6/o0YeaOsOxv5xsSf8Pm35v5CLrd7L0sk28ZylnJ8XROeg==
+urql@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-1.1.3.tgz#41fffb0a3b1a3f7ac47be55b7f84ca69875e7358"
+  integrity sha512-H6xdtT+b3n7OYG1U/ItLHTBfBpM0Kxd6FkQSYP1TvylqUeyz160whRu/XpwDRt2VwbLy5+j729wv4BF1f1zP4Q==
   dependencies:
-    create-react-context "^0.2.3"
-    wonka "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    graphql-tag "^2.10.1"
+    prop-types "^15.6.0"
+    wonka "^3.0.0"
 
 use@^3.1.0:
   version "3.1.1"
@@ -4482,11 +4418,6 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
   integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
 
-whatwg-fetch@>=0.10.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
-
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
@@ -4512,6 +4443,11 @@ wonka@^2.0.1:
   integrity sha512-xbWQpBlBOaNUeZj7IsgXMwE08HeomMQYkaUVoXIHgyAOk9bdfqOA9Ccw87cL1jgFbGOeXifO9OfgeL6vut9/8Q==
   dependencies:
     bs-rebel "^0.2.3"
+
+wonka@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/wonka/-/wonka-3.0.0.tgz#4f32a6a30e3229bae5944f002ce32d05b0423ba8"
+  integrity sha512-eDDzMU1gv1OgZG0fYom/0xi3WO4s2ILt6QvZzjcnSvFM+nzpgX4sux1+Z+LDYWhknJA9agpDADVtATZtajMtLA==
 
 worker-farm@^1.5.2:
   version "1.6.0"

--- a/examples/5-subscription/package.json
+++ b/examples/5-subscription/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "apollo-server-express": "^2.4.8",
-    "bs-platform": "^5.0.4",
+    "bs-platform": "5.0.4",
     "cors": "^2.8.5",
     "express": "^4.16.4",
     "faker": "^4.1.0",

--- a/examples/5-subscription/src/app/bindings/SubscriptionsTransportWS.re
+++ b/examples/5-subscription/src/app/bindings/SubscriptionsTransportWS.re
@@ -24,16 +24,12 @@ type subscriptionClientConfig = {
   websocketImpl,
 };
 
-type executionResult;
-
 type client = {
   .
   [@bs.meth]
   "request":
     UrqlClient.UrqlExchanges.subscriptionOperation =>
-    UrqlClient.UrqlExchanges.observableLike(
-      UrqlTypes.executionResult(executionResult),
-    ),
+    UrqlClient.UrqlExchanges.observableLike(UrqlTypes.executionResult),
 };
 
 [@bs.new] [@bs.module "subscriptions-transport-ws"]

--- a/examples/5-subscription/yarn.lock
+++ b/examples/5-subscription/yarn.lock
@@ -990,7 +990,7 @@ bs-fetch@^0.3.0:
   resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.1.tgz#9c7d074b27e6bb2b9f2ec985964f32bcac49f79e"
   integrity sha512-MxwnuuXPldXnoCtlpeN5JNbbmb1tVgsqpLfVunvuMLAIQNyP0TqoImHiQRTz38PBSN8/iX+2yVlm+PFJfnHHiA==
 
-bs-platform@^5.0.4:
+bs-platform@5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"
   integrity sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.8",
     "all-contributors-cli": "^5.4.0",
-    "bs-platform": "^5.0.4",
+    "bs-platform": "5.0.4",
     "graphql_ppx": "^0.2.7",
     "husky": "^2.4.1",
     "lint-staged": "^8.2.1",

--- a/src/UrqlClient.re
+++ b/src/UrqlClient.re
@@ -135,9 +135,9 @@ external createRequestOperationJs:
   operation =
   "createRequestOperation";
 
-let createRequestOperation = (~client, ~operationType, ~request, ~opts, ()) => {
+let createRequestOperation = (~client, ~operationType, ~request, ~opts=?, ()) => {
   let op = operationTypeToJs(operationType);
-  createRequestOperationJs(~client, ~operationType=op, ~request, ~opts, ());
+  createRequestOperationJs(~client, ~operationType=op, ~request, ~opts?, ());
 };
 
 [@bs.send]

--- a/src/UrqlTypes.re
+++ b/src/UrqlTypes.re
@@ -1,4 +1,5 @@
-/* RequestPolicy to be used for queries. Use with requestPolicyToJs for proper conversion to string. */
+/* RequestPolicy to be used for queries.
+   Use with requestPolicyToJs for proper conversion to string. */
 [@bs.deriving jsConverter]
 type requestPolicy = [
   | [@bs.as "cache-first"] `CacheFirst
@@ -7,7 +8,8 @@ type requestPolicy = [
   | [@bs.as "cache-and-network"] `CacheAndNetwork
 ];
 
-/* The GraphQL request object. Consists of a query, a unique key for the event, and, optionally, variables. */
+/* The GraphQL request object.
+   Consists of a query, a unique key for the event, and, optionally, variables. */
 [@bs.deriving abstract]
 type graphqlRequest = {
   key: int,
@@ -16,23 +18,25 @@ type graphqlRequest = {
   variables: Js.Json.t,
 };
 
-/* The result of executing a GraphQL request. Consists of optional data and errors fields. */
+/* The result of executing a GraphQL request.
+   Consists of optional data and errors fields. */
 [@bs.deriving abstract]
-type executionResult('a) = {
+type executionResult = {
   [@bs.optional]
   errors: array(UrqlCombinedError.graphqlError),
   [@bs.optional]
-  data: 'a,
+  data: Js.Json.t,
 };
 
-/* The response variant passed to render prop components (Query, Mutation, Subscription). */
+/* The response variant passed to Query, Mutation, and Subscription. */
 type response('a) =
   | Fetching
   | Data('a)
   | Error(UrqlCombinedError.t)
   | NotFound;
 
-/* OperationType for the active operation. Use with operationTypeToJs for proper conversion to string. */
+/* OperationType for the active operation.
+   Use with operationTypeToJs for proper conversion to string. */
 [@bs.deriving jsConverter]
 type operationType = [
   | [@bs.as "subscription"] `Subscription
@@ -41,7 +45,8 @@ type operationType = [
   | [@bs.as "teardown"] `Teardown
 ];
 
-/* Additional operation metadata to pass to the active operation. Currently does not support additional untyped options. */
+/* Additional operation metadata to pass to the active operation.
+   Currently does not support additional untyped options. */
 [@bs.deriving abstract]
 type operationContext = {
   [@bs.optional]
@@ -50,7 +55,8 @@ type operationContext = {
   url: string,
 };
 
-/* A partial operation context, which can be passed as the second optional argument to executeQuery, executeMutation, and executeSubscription. */
+/* A partial operation context, which can be passed as the second optional argument
+   to executeQuery, executeMutation, and executeSubscription. */
 [@bs.deriving abstract]
 type partialOperationContext = {
   [@bs.optional]
@@ -72,19 +78,16 @@ type operation = {
   context: operationContext,
 };
 
-/* The result of a GraphQL operation. */
-type operationData;
-
 [@bs.deriving abstract]
 type operationResult = {
   operation,
   [@bs.optional]
-  data: operationData,
+  data: Js.Json.t,
   [@bs.optional]
   error: UrqlCombinedError.t,
 };
 
-/* The signature of the structure created by calling `.make()` on a `graphql_ppx` module. */
+/* The signature of the Js.t created by calling `.make()` on a `graphql_ppx` module. */
 type request('response) = {
   .
   "parse": Js.Json.t => 'response,

--- a/src/UrqlTypes.re
+++ b/src/UrqlTypes.re
@@ -81,10 +81,8 @@ type operation = {
 [@bs.deriving abstract]
 type operationResult = {
   operation,
-  [@bs.optional]
-  data: Js.Json.t,
-  [@bs.optional]
-  error: UrqlCombinedError.t,
+  data: Js.Nullable.t(Js.Json.t),
+  error: Js.Nullable.t(UrqlCombinedError.t),
 };
 
 /* The signature of the Js.t created by calling `.make()` on a `graphql_ppx` module. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,7 +700,7 @@ bs-fetch@^0.3.0:
   resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.1.tgz#9c7d074b27e6bb2b9f2ec985964f32bcac49f79e"
   integrity sha512-MxwnuuXPldXnoCtlpeN5JNbbmb1tVgsqpLfVunvuMLAIQNyP0TqoImHiQRTz38PBSN8/iX+2yVlm+PFJfnHHiA==
 
-bs-platform@^5.0.4:
+bs-platform@5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"
   integrity sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==


### PR DESCRIPTION
This PR attempts to do a final(ish) type pass on `UrqlTypes` and `UrqlClient`. I think we may still need to alter the APIs for `.executeQuery`, `.executeMutation`, and `.executeSubscription` on the `client` to properly infer the type of the response. We'll probably want to do something similar to what we did for the components and hooks by passing the whole request built by `graphql_ppx`, but that's a separate follow up PR. I'm considering releasing a `v1.0.0-beta.1` after these changes get in so we can give folks the hooks publicly while I get the type inference going on these methods 😄

cc/ @gugahoa @Schmavery  