### PR TITLE
Properly send fetchOption fn to urql Client

### DIFF
--- a/__tests__/__snapshots__/UrqlClient_test.bs.js.snap
+++ b/__tests__/__snapshots__/UrqlClient_test.bs.js.snap
@@ -32,14 +32,7 @@ Client {
   "executeMutation": [Function],
   "executeQuery": [Function],
   "executeSubscription": [Function],
-  "fetchOptions": Object {
-    "headers": Object {
-      "Content-Type": "application/json",
-    },
-    "integrity": "",
-    "method": "POST",
-    "referrerPolicy": "",
-  },
+  "fetchOptions": [Function],
   "operations$": [Function],
   "reexecuteOperation": [Function],
   "results$": [Function],

--- a/__tests__/__snapshots__/UrqlClient_test.bs.js.snap
+++ b/__tests__/__snapshots__/UrqlClient_test.bs.js.snap
@@ -10,10 +10,7 @@ Client {
   "executeMutation": [Function],
   "executeQuery": [Function],
   "executeSubscription": [Function],
-  "fetchOptions": Object {
-    "integrity": "",
-    "referrerPolicy": "",
-  },
+  "fetchOptions": undefined,
   "operations$": [Function],
   "reexecuteOperation": [Function],
   "results$": [Function],
@@ -77,10 +74,7 @@ Client {
   "executeMutation": [Function],
   "executeQuery": [Function],
   "executeSubscription": [Function],
-  "fetchOptions": Object {
-    "integrity": "",
-    "referrerPolicy": "",
-  },
+  "fetchOptions": undefined,
   "operations$": [Function],
   "reexecuteOperation": [Function],
   "results$": [Function],

--- a/src/UrqlClient.re
+++ b/src/UrqlClient.re
@@ -2,14 +2,16 @@ open UrqlTypes;
 type t;
 
 /* Helpers for supporting polymorphic fetchOptions. */
-type fetchOptions =
-  | FetchOpts(Fetch.requestInit)
-  | FetchFn(unit => Fetch.requestInit);
+type fetchOptions('a) =
+  | FetchOpts(Fetch.requestInit): fetchOptions(Fetch.requestInit)
+  | FetchFn(unit => Fetch.requestInit)
+    : fetchOptions(unit => Fetch.requestInit);
 
-let unwrapFetchOptions = fetchOptions =>
+let unwrapFetchOptions = (type a, fetchOptions: option(fetchOptions(a))): a =>
   switch (fetchOptions) {
-  | FetchOpts(opts) => opts
-  | FetchFn(fn) => fn()
+  | Some(FetchOpts(opts)) => opts
+  | Some(FetchFn(fn)) => fn
+  | None => Obj.magic(Fetch.RequestInit.make())
   };
 
 /* A module for binding exchange types and urql's exposed exchanges. Since this module
@@ -72,15 +74,16 @@ module UrqlExchanges = {
 };
 
 [@bs.deriving abstract]
-type clientOptions = {
+type clientOptions('a) = {
   url: string,
   [@bs.optional]
-  fetchOptions: Fetch.requestInit,
+  fetchOptions: 'a,
   [@bs.optional]
   exchanges: array(UrqlExchanges.exchange),
 };
 
-[@bs.new] [@bs.module "urql"] external client: clientOptions => t = "Client";
+[@bs.new] [@bs.module "urql"]
+external client: clientOptions('a) => t = "Client";
 
 [@bs.send]
 external executeQuery:
@@ -150,7 +153,7 @@ external dispatchOperation: (~client: t, ~operation: operation) => unit = "";
 let make =
     (
       ~url,
-      ~fetchOptions=FetchOpts(Fetch.RequestInit.make()),
+      ~fetchOptions=?,
       ~exchanges=[|
                    UrqlExchanges.dedupExchange,
                    UrqlExchanges.cacheExchange,

--- a/src/UrqlClient.re
+++ b/src/UrqlClient.re
@@ -7,11 +7,12 @@ type fetchOptions('a) =
   | FetchFn(unit => Fetch.requestInit)
     : fetchOptions(unit => Fetch.requestInit);
 
-let unwrapFetchOptions = (type a, fetchOptions: option(fetchOptions(a))): a =>
+let unwrapFetchOptions =
+    (type a, fetchOptions: option(fetchOptions(a))): option(a) =>
   switch (fetchOptions) {
-  | Some(FetchOpts(opts)) => opts
-  | Some(FetchFn(fn)) => fn
-  | None => Obj.magic(Fetch.RequestInit.make())
+  | Some(FetchOpts(opts)) => Some(opts)
+  | Some(FetchFn(fn)) => Some(fn)
+  | None => None
   };
 
 /* A module for binding exchange types and urql's exposed exchanges. Since this module


### PR DESCRIPTION
When sending a `FetchFn` as `fetchOptions`, it was being called during the `Client` instantiation, but the expected behavior would be for it to be called on demand, as it is on upstream `urql` lib

This fix makes it possible to properly send a function as a `fetchOptions`, but introduce type unsafety with `Obj.magic` being called at `unwrapFetchOptions` where the type checker will just trust the user type annotation when calling it with a `None` value

To properly address that issue I believe the most sensible would be to not expose `unwrapFetchOptions` to any user. Any thoughts?

I'm marking this as WIP until that issue above is properly discussed