### PR TITLE
Improve combinedError API. Bind using OCaml classes.

### DIFF
--- a/examples/2-query/src/Monster.re
+++ b/examples/2-query/src/Monster.re
@@ -82,7 +82,7 @@ let make = (~pokemon: string) => {
     }
   | Fetching => <div> "Loading"->React.string </div>
   | Error(e) =>
-    switch (e##networkError->Js.Nullable.toOption) {
+    switch (e.networkError) {
     | Some(_exn) => <div> "Network Error"->React.string </div>
     | None => <div> "No Network Error"->React.string </div>
     }

--- a/examples/2-query/src/Monster.re
+++ b/examples/2-query/src/Monster.re
@@ -81,7 +81,11 @@ let make = (~pokemon: string) => {
     | None => React.null
     }
   | Fetching => <div> "Loading"->React.string </div>
-  | Error(_e) => <div> "Error"->React.string </div>
+  | Error(e) =>
+    switch (e##networkError->Js.Nullable.toOption) {
+    | Some(_exn) => <div> "Network Error"->React.string </div>
+    | None => <div> "No Network Error"->React.string </div>
+    }
   | NotFound => <div> "Not Found"->React.string </div>
   };
 };

--- a/src/ReasonUrql.re
+++ b/src/ReasonUrql.re
@@ -25,7 +25,7 @@ module Hooks = {
     Types.hookResponse('ret) = {
       fetching: bool,
       data: option('ret),
-      error: option(UrqlCombinedError.t),
+      error: option(UrqlCombinedError.combinedError),
       response: Types.response('ret),
     };
   include UrqlUseMutation;

--- a/src/UrqlTypes.re
+++ b/src/UrqlTypes.re
@@ -32,7 +32,7 @@ type executionResult = {
 type response('a) =
   | Fetching
   | Data('a)
-  | Error(UrqlCombinedError.t)
+  | Error(UrqlCombinedError.combinedError)
   | NotFound;
 
 /* OperationType for the active operation.
@@ -96,6 +96,6 @@ type request('response) = {
 type hookResponse('ret) = {
   fetching: bool,
   data: option('ret),
-  error: option(UrqlCombinedError.t),
+  error: option(UrqlCombinedError.combinedError),
   response: response('ret),
 };

--- a/src/components/UrqlMutation.re
+++ b/src/components/UrqlMutation.re
@@ -11,7 +11,7 @@ type mutationRenderPropsJs = {
 type mutationRenderProps('response) = {
   fetching: bool,
   data: option('response),
-  error: option(UrqlCombinedError.t),
+  error: option(UrqlCombinedError.combinedError),
   executeMutation: unit => Js.Promise.t(UrqlTypes.operationResult),
   response: UrqlTypes.response('response),
 };
@@ -26,7 +26,10 @@ module MutationJs = {
 
 let urqlDataToRecord = (parse, variables, result) => {
   let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
-  let error = result->errorGet;
+  let error =
+    result
+    ->errorGet
+    ->Belt.Option.map(UrqlCombinedError.combinedErrorToRecord);
   let fetching = result->fetchingGet;
   let executeMutationFn = result->executeMutationGet;
   let executeMutation = () => executeMutationFn(Some(variables));

--- a/src/components/UrqlQuery.re
+++ b/src/components/UrqlQuery.re
@@ -10,7 +10,7 @@ type queryRenderPropsJs = {
 type queryRenderProps('response) = {
   fetching: bool,
   data: option('response),
-  error: option(UrqlCombinedError.t),
+  error: option(UrqlCombinedError.combinedError),
   executeQuery: option(Js.Json.t) => Js.Promise.t(UrqlTypes.operationResult),
   response: UrqlTypes.response('response),
 };
@@ -31,7 +31,10 @@ module QueryJs = {
 
 let urqlDataToRecord = (parse, result) => {
   let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
-  let error = result->errorGet;
+  let error =
+    result
+    ->errorGet
+    ->Belt.Option.map(UrqlCombinedError.combinedErrorToRecord);
   let fetching = result->fetchingGet;
   let executeQuery = result->executeQueryGet;
 

--- a/src/components/UrqlSubscription.re
+++ b/src/components/UrqlSubscription.re
@@ -11,7 +11,7 @@ type subscriptionRenderPropsJs('ret) = {
 type subscriptionRenderProps('ret) = {
   fetching: bool,
   data: option('ret),
-  error: option(UrqlCombinedError.t),
+  error: option(UrqlCombinedError.combinedError),
   response: UrqlTypes.response('ret),
 };
 
@@ -30,7 +30,10 @@ module SubscriptionJs = {
 
 let urqlDataToRecord = (parse, result) => {
   let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
-  let error = result->errorGet;
+  let error =
+    result
+    ->errorGet
+    ->Belt.Option.map(UrqlCombinedError.combinedErrorToRecord);
   let fetching = result->fetchingGet;
 
   let response =

--- a/src/hooks/UrqlUseMutation.re
+++ b/src/hooks/UrqlUseMutation.re
@@ -8,8 +8,7 @@ type useMutationResponseJs = {
   error: UrqlCombinedError.t,
 };
 
-type executeMutation =
-  option(Js.Json.t) => Js.Promise.t(operationResult);
+type executeMutation = option(Js.Json.t) => Js.Promise.t(operationResult);
 
 [@bs.module "urql"]
 external useMutationJs: string => (useMutationResponseJs, executeMutation) =
@@ -18,7 +17,10 @@ external useMutationJs: string => (useMutationResponseJs, executeMutation) =
 let useMutationResponseToRecord =
     (parse: Js.Json.t => 'response, result: useMutationResponseJs) => {
   let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
-  let error = result->errorGet;
+  let error =
+    result
+    ->errorGet
+    ->Belt.Option.map(UrqlCombinedError.combinedErrorToRecord);
   let fetching = result->fetchingGet;
 
   let response =

--- a/src/hooks/UrqlUseQuery.re
+++ b/src/hooks/UrqlUseQuery.re
@@ -28,7 +28,10 @@ type useQueryResponse('response) = (
 
 let useQueryResponseToRecord = (parse, result) => {
   let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
-  let error = result->errorGet;
+  let error =
+    result
+    ->errorGet
+    ->Belt.Option.map(UrqlCombinedError.combinedErrorToRecord);
   let fetching = result->fetchingGet;
 
   let response =

--- a/src/hooks/UrqlUseQuery.re
+++ b/src/hooks/UrqlUseQuery.re
@@ -13,13 +13,12 @@ type useQueryArgs = {
   query: string,
   variables: Js.Json.t,
   [@bs.optional]
-  requestPolicy: requestPolicy,
+  requestPolicy,
   [@bs.optional]
   pause: bool,
 };
 
-type partialOperationContextFn =
-  option(partialOperationContext) => unit;
+type partialOperationContextFn = option(partialOperationContext) => unit;
 type useQueryResponseJs = (useQueryStateJs, partialOperationContextFn);
 
 type useQueryResponse('response) = (

--- a/src/hooks/UrqlUseSubscription.re
+++ b/src/hooks/UrqlUseSubscription.re
@@ -27,7 +27,10 @@ external useSubscriptionJs:
 
 let useSubscriptionResponseToRecord = (parse, result) => {
   let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
-  let error = result->errorGet;
+  let error =
+    result
+    ->errorGet
+    ->Belt.Option.map(UrqlCombinedError.combinedErrorToRecord);
   let fetching = result->fetchingGet;
 
   let response =

--- a/src/utils/UrqlCombinedError.re
+++ b/src/utils/UrqlCombinedError.re
@@ -54,9 +54,23 @@ class type _combinedError =
   {
     pub networkError: Js.Nullable.t(Js.Exn.t);
     pub graphqlErrors: Js.Nullable.t(array(graphqlError));
-    pub response: 'response;
+    pub response: Js.Nullable.t(Fetch.response);
   };
 
 type t = Js.t(_combinedError);
+
+type combinedError = {
+  networkError: option(Js.Exn.t),
+  graphqlErrors: option(array(graphqlError)),
+  response: option(Fetch.response),
+};
+
+let combinedErrorToRecord = (err: t): combinedError => {
+  {
+    networkError: err##networkError->Js.Nullable.toOption,
+    graphqlErrors: err##graphqlErrors->Js.Nullable.toOption,
+    response: err##response->Js.Nullable.toOption,
+  };
+};
 
 [@bs.module "urql"] external combinedError: t = "CombinedError";

--- a/src/utils/UrqlCombinedError.re
+++ b/src/utils/UrqlCombinedError.re
@@ -1,12 +1,10 @@
-type t;
-
 /* A message describing the Error for debugging purposes. */
 type message = string;
 
+[@bs.deriving abstract]
 type sourceLocation = {
-  .
-  "line": int,
-  "column": int,
+  line: int,
+  column: int,
 };
 
 /* An array of { line, column } locations within the source GraphQL document
@@ -20,11 +18,11 @@ type path;
 type astNode;
 
 /* The source GraphQL document corresponding to this error. */
+[@bs.deriving abstract]
 type source = {
-  .
-  "body": string,
-  "name": string,
-  "locationOffset": sourceLocation,
+  body: string,
+  name: string,
+  locationOffset: sourceLocation,
 };
 
 /* An array of character offsets within the source GraphQL document which correspond to this error. */
@@ -39,24 +37,26 @@ type extension;
 /* A simple binding to the GraphQL error type exposed by graphql-js. See:
     https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/graphql/error/GraphQLError.d.ts.
    */
+[@bs.deriving abstract]
 type graphqlError = {
-  .
-  "message": Js.Nullable.t(message),
-  "locations": Js.Nullable.t(locations),
-  "path": Js.Nullable.t(array(path)),
-  "nodes": Js.Nullable.t(array(astNode)),
-  "source": Js.Nullable.t(source),
-  "positions": Js.Nullable.t(positions),
-  "originalError": Js.Nullable.t(originalError),
-  "extensions": Js.Nullable.t(Js.Dict.t(extension)),
+  message: Js.Nullable.t(message),
+  locations: Js.Nullable.t(locations),
+  path: Js.Nullable.t(array(path)),
+  nodes: Js.Nullable.t(array(astNode)),
+  source: Js.Nullable.t(source),
+  positions: Js.Nullable.t(positions),
+  originalError: Js.Nullable.t(originalError),
+  extensions: Js.Nullable.t(Js.Dict.t(extension)),
 };
 
-type combinedError('a) = {
-  .
-  "networkError": Js.Nullable.t(Js.Exn.t),
-  "graphqlErrors": Js.Nullable.t(array(graphqlError)),
-  "response": Js.Nullable.t('a),
-};
+class type _combinedError =
+  [@bs]
+  {
+    pub networkError: Js.Nullable.t(Js.Exn.t);
+    pub graphqlErrors: Js.Nullable.t(array(graphqlError));
+    pub response: 'response;
+  };
 
-[@bs.new] [@bs.module "urql"]
-external combinedError: combinedError('a) => t = "CombinedError";
+type t = Js.t(_combinedError);
+
+[@bs.module "urql"] external combinedError: t = "CombinedError";


### PR DESCRIPTION
This PR adds nicer bindings for `urql`'s `CombinedError` API. The previous binding were just wrong, so you couldn't actually access anything on the `Error(e)` variant. Now, `e` will come back with fields for `networkError`, `graphqlErrors`, and `response`. These fields are accessible using `##`, i.e.:

```reason
switch (e##networkError) {
| Some(exn) => /* do something with exn of type Js.Exn.t */
| None => /* no network error occurred */
}
```

I added an example of the above to `Monster.re` in `examples/2-query`.

![190718_combined_error_demo](https://user-images.githubusercontent.com/19421190/61498737-5002ab80-a979-11e9-89d8-86f679a7e738.gif)

Since `CombinedError` is a JS class instance on the `urql` side, I opted to use OCaml classes to bind it as described here: https://bucklescript.github.io/docs/en/class#bind-to-js-classes

@gugahoa let me know if this sounds like a decent enough API to you! I also thought about trying to do some error conversion to turn this into a record type, but wanted to start small and get thoughts first.