### PR TITLE
Add proper type inference to execute* methods on client.

### DIFF
--- a/examples/1-execute-query-mutation/src/Previewer.re
+++ b/examples/1-execute-query-mutation/src/Previewer.re
@@ -1,4 +1,5 @@
 open ReasonUrql;
+open Types;
 
 let client = Client.make(~url="https://formidadog-ql.now.sh", ());
 
@@ -60,18 +61,36 @@ let make = () => {
   let executeQuery = () =>
     Client.executeQuery(~client, ~request=queryRequest, ())
     |> Wonka.subscribe((. data) =>
-         switch (Js.Json.stringifyAny(data)) {
-         | Some(d) => dispatch(SetQuery(d))
-         | None => ()
+         switch (data.response) {
+         | Data(d) =>
+           switch (Js.Json.stringifyAny(d)) {
+           | Some(s) => dispatch(SetQuery(s))
+           | None => ()
+           }
+         | Error(e) =>
+           switch (Js.Json.stringifyAny(e)) {
+           | Some(s) => dispatch(SetQuery(s))
+           | None => ()
+           }
+         | _ => ()
          }
        );
 
   let executeMutation = () =>
     Client.executeMutation(~client, ~request=mutationRequest, ())
     |> Wonka.subscribe((. data) =>
-         switch (Js.Json.stringifyAny(data)) {
-         | Some(d) => dispatch(SetMutation(d))
-         | None => ()
+         switch (data.response) {
+         | Data(d) =>
+           switch (Js.Json.stringifyAny(d)) {
+           | Some(s) => dispatch(SetQuery(s))
+           | None => ()
+           }
+         | Error(e) =>
+           switch (Js.Json.stringifyAny(e)) {
+           | Some(s) => dispatch(SetQuery(s))
+           | None => ()
+           }
+         | _ => ()
          }
        );
 

--- a/examples/1-execute-query-mutation/src/Previewer.re
+++ b/examples/1-execute-query-mutation/src/Previewer.re
@@ -1,7 +1,7 @@
 open ReasonUrql;
-open Types;
+open Client;
 
-let client = Client.make(~url="https://formidadog-ql.now.sh", ());
+let client = make(~url="https://formidadog-ql.now.sh", ());
 
 module GetAllDogs = [%graphql
   {|
@@ -59,7 +59,7 @@ let make = () => {
     );
 
   let executeQuery = () =>
-    Client.executeQuery(~client, ~request=queryRequest, ())
+    executeQuery(~client, ~request=queryRequest, ())
     |> Wonka.subscribe((. data) =>
          switch (data.response) {
          | Data(d) =>
@@ -77,7 +77,7 @@ let make = () => {
        );
 
   let executeMutation = () =>
-    Client.executeMutation(~client, ~request=mutationRequest, ())
+    executeMutation(~client, ~request=mutationRequest, ())
     |> Wonka.subscribe((. data) =>
          switch (data.response) {
          | Data(d) =>

--- a/src/ReasonUrql.re
+++ b/src/ReasonUrql.re
@@ -1,4 +1,15 @@
-module Client = UrqlClient;
+module Types = UrqlTypes;
+
+module Client = {
+  type clientResponse('ret) =
+    Types.clientResponse('ret) = {
+      data: option('ret),
+      error: option(UrqlCombinedError.combinedError),
+      response: Types.response('ret),
+    };
+
+  include UrqlClient;
+};
 
 module Context = UrqlContext;
 module Provider = UrqlContext.Provider;
@@ -11,8 +22,6 @@ module Mutation = UrqlMutation;
 module Subscription = UrqlSubscription.Subscription;
 
 module SubscriptionWithHandler = UrqlSubscription.SubscriptionWithHandler;
-
-module Types = UrqlTypes;
 
 module Request = UrqlRequest;
 

--- a/src/UrqlClient.re
+++ b/src/UrqlClient.re
@@ -87,37 +87,97 @@ type clientOptions('a) = {
 external client: clientOptions('a) => t = "Client";
 
 [@bs.send]
-external executeQuery:
+external urqlExecuteQuery:
   (
     ~client: t,
     ~query: graphqlRequest,
     ~opts: partialOperationContext=?,
     unit
   ) =>
-  Wonka.Types.sourceT('a) =
-  "";
+  Wonka.Types.sourceT({. "data": Js.Json.t}) =
+  "executeQuery";
+
+let executeQuery =
+    (
+      ~client: t,
+      ~request: request('response),
+      ~opts: option(partialOperationContext)=?,
+      (),
+    )
+    : Wonka.Types.sourceT('response) => {
+  let req =
+    UrqlRequest.createRequest(
+      ~query=request##query,
+      ~variables=request##variables,
+      (),
+    );
+  let parse = request##parse;
+
+  urqlExecuteQuery(~client, ~query=req, ~opts?, ())
+  |> Wonka.map((. res) => parse(res##data));
+};
 
 [@bs.send]
-external executeMutation:
+external urqlExecuteMutation:
   (
     ~client: t,
     ~mutation: graphqlRequest,
     ~opts: partialOperationContext=?,
     unit
   ) =>
-  Wonka.Types.sourceT('a) =
-  "";
+  Wonka.Types.sourceT({. "data": Js.Json.t}) =
+  "executeMutation";
+
+let executeMutation =
+    (
+      ~client: t,
+      ~request: request('response),
+      ~opts: option(partialOperationContext)=?,
+      (),
+    )
+    : Wonka.Types.sourceT('response) => {
+  let req =
+    UrqlRequest.createRequest(
+      ~query=request##query,
+      ~variables=request##variables,
+      (),
+    );
+  let parse = request##parse;
+
+  urqlExecuteMutation(~client, ~mutation=req, ~opts?, ())
+  |> Wonka.map((. res) => parse(res##data));
+};
 
 [@bs.send]
-external executeSubscription:
+external urqlExecuteSubscription:
   (
     ~client: t,
     ~subscription: graphqlRequest,
     ~opts: partialOperationContext=?,
     unit
   ) =>
-  Wonka.Types.sourceT('a) =
-  "";
+  Wonka.Types.sourceT({. "data": Js.Json.t}) =
+  "executeSubscription";
+
+let executeSubscription =
+    (
+      ~client: t,
+      ~request: request('response),
+      ~opts: option(partialOperationContext)=?,
+      (),
+    )
+    : Wonka.Types.sourceT('response) => {
+  let req =
+    UrqlRequest.createRequest(
+      ~query=request##query,
+      ~variables=request##variables,
+      (),
+    );
+  let parse = request##parse;
+
+  urqlExecuteSubscription(~client, ~subscription=req, ~opts?, ())
+  |> Wonka.map((. res) => parse(res##data));
+};
 
 [@bs.send]
 external executeRequestOperation:

--- a/src/UrqlClient.re
+++ b/src/UrqlClient.re
@@ -95,7 +95,7 @@ external urqlExecuteQuery:
     ~opts: partialOperationContext=?,
     unit
   ) =>
-  Wonka.Types.sourceT(jsResponse) =
+  Wonka.Types.sourceT(operationResult) =
   "executeQuery";
 
 let executeQuery =
@@ -105,7 +105,7 @@ let executeQuery =
       ~opts: option(partialOperationContext)=?,
       (),
     )
-    : Wonka.Types.sourceT(hookResponse('response)) => {
+    : Wonka.Types.sourceT(clientResponse('response)) => {
   let req =
     UrqlRequest.createRequest(
       ~query=request##query,
@@ -115,7 +115,7 @@ let executeQuery =
   let parse = request##parse;
 
   urqlExecuteQuery(~client, ~query=req, ~opts?, ())
-  |> Wonka.map((. res) => urqlResponseToReason(parse, res));
+  |> Wonka.map((. res) => urqlClientResponseToReason(parse, res));
 };
 
 [@bs.send]
@@ -126,7 +126,7 @@ external urqlExecuteMutation:
     ~opts: partialOperationContext=?,
     unit
   ) =>
-  Wonka.Types.sourceT(jsResponse) =
+  Wonka.Types.sourceT(operationResult) =
   "executeMutation";
 
 let executeMutation =
@@ -136,7 +136,7 @@ let executeMutation =
       ~opts: option(partialOperationContext)=?,
       (),
     )
-    : Wonka.Types.sourceT(hookResponse('response)) => {
+    : Wonka.Types.sourceT(clientResponse('response)) => {
   let req =
     UrqlRequest.createRequest(
       ~query=request##query,
@@ -146,7 +146,7 @@ let executeMutation =
   let parse = request##parse;
 
   urqlExecuteMutation(~client, ~mutation=req, ~opts?, ())
-  |> Wonka.map((. res) => urqlResponseToReason(parse, res));
+  |> Wonka.map((. res) => urqlClientResponseToReason(parse, res));
 };
 
 [@bs.send]
@@ -157,7 +157,7 @@ external urqlExecuteSubscription:
     ~opts: partialOperationContext=?,
     unit
   ) =>
-  Wonka.Types.sourceT(jsResponse) =
+  Wonka.Types.sourceT(operationResult) =
   "executeSubscription";
 
 let executeSubscription =
@@ -167,7 +167,7 @@ let executeSubscription =
       ~opts: option(partialOperationContext)=?,
       (),
     )
-    : Wonka.Types.sourceT(hookResponse('response)) => {
+    : Wonka.Types.sourceT(clientResponse('response)) => {
   let req =
     UrqlRequest.createRequest(
       ~query=request##query,
@@ -177,7 +177,7 @@ let executeSubscription =
   let parse = request##parse;
 
   urqlExecuteSubscription(~client, ~subscription=req, ~opts?, ())
-  |> Wonka.map((. res) => urqlResponseToReason(parse, res));
+  |> Wonka.map((. res) => urqlClientResponseToReason(parse, res));
 };
 
 [@bs.send]

--- a/src/UrqlClient.re
+++ b/src/UrqlClient.re
@@ -1,4 +1,5 @@
 open UrqlTypes;
+open UrqlConverters;
 type t;
 
 /* Helpers for supporting polymorphic fetchOptions. */
@@ -94,7 +95,7 @@ external urqlExecuteQuery:
     ~opts: partialOperationContext=?,
     unit
   ) =>
-  Wonka.Types.sourceT({. "data": Js.Json.t}) =
+  Wonka.Types.sourceT(jsResponse) =
   "executeQuery";
 
 let executeQuery =
@@ -104,7 +105,7 @@ let executeQuery =
       ~opts: option(partialOperationContext)=?,
       (),
     )
-    : Wonka.Types.sourceT('response) => {
+    : Wonka.Types.sourceT(hookResponse('response)) => {
   let req =
     UrqlRequest.createRequest(
       ~query=request##query,
@@ -114,7 +115,7 @@ let executeQuery =
   let parse = request##parse;
 
   urqlExecuteQuery(~client, ~query=req, ~opts?, ())
-  |> Wonka.map((. res) => parse(res##data));
+  |> Wonka.map((. res) => urqlResponseToReason(parse, res));
 };
 
 [@bs.send]
@@ -125,7 +126,7 @@ external urqlExecuteMutation:
     ~opts: partialOperationContext=?,
     unit
   ) =>
-  Wonka.Types.sourceT({. "data": Js.Json.t}) =
+  Wonka.Types.sourceT(jsResponse) =
   "executeMutation";
 
 let executeMutation =
@@ -135,7 +136,7 @@ let executeMutation =
       ~opts: option(partialOperationContext)=?,
       (),
     )
-    : Wonka.Types.sourceT('response) => {
+    : Wonka.Types.sourceT(hookResponse('response)) => {
   let req =
     UrqlRequest.createRequest(
       ~query=request##query,
@@ -145,7 +146,7 @@ let executeMutation =
   let parse = request##parse;
 
   urqlExecuteMutation(~client, ~mutation=req, ~opts?, ())
-  |> Wonka.map((. res) => parse(res##data));
+  |> Wonka.map((. res) => urqlResponseToReason(parse, res));
 };
 
 [@bs.send]
@@ -156,7 +157,7 @@ external urqlExecuteSubscription:
     ~opts: partialOperationContext=?,
     unit
   ) =>
-  Wonka.Types.sourceT({. "data": Js.Json.t}) =
+  Wonka.Types.sourceT(jsResponse) =
   "executeSubscription";
 
 let executeSubscription =
@@ -166,7 +167,7 @@ let executeSubscription =
       ~opts: option(partialOperationContext)=?,
       (),
     )
-    : Wonka.Types.sourceT('response) => {
+    : Wonka.Types.sourceT(hookResponse('response)) => {
   let req =
     UrqlRequest.createRequest(
       ~query=request##query,
@@ -176,7 +177,7 @@ let executeSubscription =
   let parse = request##parse;
 
   urqlExecuteSubscription(~client, ~subscription=req, ~opts?, ())
-  |> Wonka.map((. res) => parse(res##data));
+  |> Wonka.map((. res) => urqlResponseToReason(parse, res));
 };
 
 [@bs.send]

--- a/src/UrqlTypes.re
+++ b/src/UrqlTypes.re
@@ -28,13 +28,6 @@ type executionResult = {
   data: Js.Json.t,
 };
 
-/* The response variant passed to Query, Mutation, and Subscription. */
-type response('a) =
-  | Fetching
-  | Data('a)
-  | Error(UrqlCombinedError.combinedError)
-  | NotFound;
-
 /* OperationType for the active operation.
    Use with operationTypeToJs for proper conversion to string. */
 [@bs.deriving jsConverter]
@@ -91,6 +84,21 @@ type request('response) = {
   "parse": Js.Json.t => 'response,
   "query": string,
   "variables": Js.Json.t,
+};
+
+/* The response variant wraps the parsed result of executing a GraphQL operation. */
+type response('response) =
+  | Fetching
+  | Data('response)
+  | Error(UrqlCombinedError.combinedError)
+  | NotFound;
+
+[@bs.deriving abstract]
+type jsResponse = {
+  fetching: bool,
+  data: Js.Nullable.t(Js.Json.t),
+  [@bs.optional]
+  error: UrqlCombinedError.t,
 };
 
 type hookResponse('ret) = {

--- a/src/UrqlTypes.re
+++ b/src/UrqlTypes.re
@@ -93,12 +93,10 @@ type response('response) =
   | Error(UrqlCombinedError.combinedError)
   | NotFound;
 
-[@bs.deriving abstract]
-type jsResponse = {
-  fetching: bool,
-  data: Js.Nullable.t(Js.Json.t),
-  [@bs.optional]
-  error: UrqlCombinedError.t,
+type clientResponse('ret) = {
+  data: option('ret),
+  error: option(UrqlCombinedError.combinedError),
+  response: response('ret),
 };
 
 type hookResponse('ret) = {
@@ -106,4 +104,13 @@ type hookResponse('ret) = {
   data: option('ret),
   error: option(UrqlCombinedError.combinedError),
   response: response('ret),
+};
+
+[@bs.deriving abstract]
+type jsResponse = {
+  fetching: bool,
+  [@bs.as "data"]
+  jsData: Js.Nullable.t(Js.Json.t),
+  [@bs.optional] [@bs.as "error"]
+  jsError: UrqlCombinedError.t,
 };

--- a/src/hooks/UrqlUseMutation.re
+++ b/src/hooks/UrqlUseMutation.re
@@ -1,46 +1,18 @@
 open UrqlTypes;
-
-[@bs.deriving abstract]
-type useMutationResponseJs = {
-  fetching: bool,
-  data: Js.Nullable.t(Js.Json.t),
-  [@bs.optional]
-  error: UrqlCombinedError.t,
-};
+open UrqlConverters;
 
 type executeMutation = option(Js.Json.t) => Js.Promise.t(operationResult);
 
 [@bs.module "urql"]
-external useMutationJs: string => (useMutationResponseJs, executeMutation) =
+external useMutationJs: string => (jsResponse, executeMutation) =
   "useMutation";
-
-let useMutationResponseToRecord =
-    (parse: Js.Json.t => 'response, result: useMutationResponseJs) => {
-  let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
-  let error =
-    result
-    ->errorGet
-    ->Belt.Option.map(UrqlCombinedError.combinedErrorToRecord);
-  let fetching = result->fetchingGet;
-
-  let response =
-    switch (fetching, data, error) {
-    | (true, _, _) => Fetching
-    | (false, Some(data), _) => Data(data)
-    | (false, _, Some(error)) => Error(error)
-    | (false, None, None) => NotFound
-    };
-
-  {fetching, data, error, response};
-};
 
 let useMutation = (~request: request('response)) => {
   let (useMutationResponseJs, executeMutationJs) =
     useMutationJs(request##query);
   let useMutationResponse =
     React.useMemo2(
-      () =>
-        useMutationResponseJs |> useMutationResponseToRecord(request##parse),
+      () => useMutationResponseJs |> urqlResponseToReason(request##parse),
       (request##parse, useMutationResponseJs),
     );
   let executeMutation =

--- a/src/utils/UrqlConverters.re
+++ b/src/utils/UrqlConverters.re
@@ -1,10 +1,29 @@
 open UrqlTypes;
 
-let urqlResponseToReason = (parse: Js.Json.t => 'response, result: jsResponse) => {
+let urqlClientResponseToReason =
+    (parse: Js.Json.t => 'response, result: operationResult) => {
   let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
   let error =
     result
     ->errorGet
+    ->Js.Nullable.toOption
+    ->Belt.Option.map(UrqlCombinedError.combinedErrorToRecord);
+
+  let response =
+    switch (data, error) {
+    | (Some(data), _) => Data(data)
+    | (None, Some(error)) => Error(error)
+    | (None, None) => NotFound
+    };
+
+  {data, error, response};
+};
+
+let urqlResponseToReason = (parse: Js.Json.t => 'response, result: jsResponse) => {
+  let data = result->jsDataGet->Js.Nullable.toOption->Belt.Option.map(parse);
+  let error =
+    result
+    ->jsErrorGet
     ->Belt.Option.map(UrqlCombinedError.combinedErrorToRecord);
   let fetching = result->fetchingGet;
 

--- a/src/utils/UrqlConverters.re
+++ b/src/utils/UrqlConverters.re
@@ -1,0 +1,20 @@
+open UrqlTypes;
+
+let urqlResponseToReason = (parse: Js.Json.t => 'response, result: jsResponse) => {
+  let data = result->dataGet->Js.Nullable.toOption->Belt.Option.map(parse);
+  let error =
+    result
+    ->errorGet
+    ->Belt.Option.map(UrqlCombinedError.combinedErrorToRecord);
+  let fetching = result->fetchingGet;
+
+  let response =
+    switch (fetching, data, error) {
+    | (true, _, _) => Fetching
+    | (false, Some(data), _) => Data(data)
+    | (false, _, Some(error)) => Error(error)
+    | (false, None, None) => NotFound
+    };
+
+  {fetching, data, error, response};
+};


### PR DESCRIPTION
Fix #90. 

As @Schmavery pointed out in that issue, the `client`'s `execute*` methods weren't correctly inferring the types of the response data. Part of the reason was that we were just directly using `Request.createRequest`, which didn't forward along the `parse` function from the `graphql_ppx` query module (the secret sauce that allows us to infer types properly).

This PR fixes this by changing up the API a bit. `Client.execute*` methods now accept the full `graphql_ppx` query module (or a `Js.t` that fulfills the same contract if not using `graphql_ppx`), which allows us to use that `parse` function to properly infer types. In a lot of ways this mimics what we do in our hooks and components 😄

cc/ @gugahoa including you as well – let me know what you think of this. @Schmavery if you feel good about this I'll make sure to add you as a co-author on the commit since your sample was the main inspiration for these changes.

I'll happily publish another beta release right after this gets merged so folks can pick it up.