### PR TITLE
Move Error branch upward

### DIFF
--- a/src/components/UrqlMutation.re
+++ b/src/components/UrqlMutation.re
@@ -43,8 +43,8 @@ let urqlMutationResponseToReason =
   let response =
     switch (fetching, data, error) {
     | (true, _, _) => UrqlTypes.Fetching
-    | (false, Some(data), _) => Data(data)
     | (false, _, Some(error)) => Error(error)
+    | (false, Some(data), _) => Data(data)
     | (false, None, None) => NotFound
     };
 

--- a/src/components/UrqlQuery.re
+++ b/src/components/UrqlQuery.re
@@ -45,8 +45,8 @@ let urqlQueryResponseToReason =
   let response =
     switch (fetching, data, error) {
     | (true, _, _) => UrqlTypes.Fetching
-    | (false, Some(data), _) => Data(data)
     | (false, _, Some(error)) => Error(error)
+    | (false, Some(data), _) => Data(data)
     | (false, None, None) => NotFound
     };
 

--- a/src/components/UrqlSubscription.re
+++ b/src/components/UrqlSubscription.re
@@ -39,9 +39,9 @@ let urqlDataToRecord = (parse, result) => {
   let response =
     switch (fetching, data, error) {
     | (true, None, _) => Fetching
+    | (false, _, Some(error)) => Error(error)
     | (true, Some(data), _) => Data(data)
     | (false, Some(data), _) => Data(data)
-    | (false, _, Some(error)) => Error(error)
     | (false, None, None) => NotFound
     };
 

--- a/src/hooks/UrqlUseMutation.re
+++ b/src/hooks/UrqlUseMutation.re
@@ -18,8 +18,8 @@ let urqlResponseToReason = (parse: Js.Json.t => 'response, result: jsResponse) =
   let response =
     switch (fetching, data, error) {
     | (true, _, _) => Fetching
-    | (false, Some(data), _) => Data(data)
     | (false, _, Some(error)) => Error(error)
+    | (false, Some(data), _) => Data(data)
     | (false, None, None) => NotFound
     };
 

--- a/src/hooks/UrqlUseQuery.re
+++ b/src/hooks/UrqlUseQuery.re
@@ -33,8 +33,8 @@ let urqlResponseToReason = (parse: Js.Json.t => 'response, result: jsResponse) =
   let response =
     switch (fetching, data, error) {
     | (true, _, _) => Fetching
-    | (false, Some(data), _) => Data(data)
     | (false, _, Some(error)) => Error(error)
+    | (false, Some(data), _) => Data(data)
     | (false, None, None) => NotFound
     };
 

--- a/src/hooks/UrqlUseSubscription.re
+++ b/src/hooks/UrqlUseSubscription.re
@@ -36,9 +36,9 @@ let useSubscriptionResponseToRecord = (parse, result) => {
   let response =
     switch (fetching, data, error) {
     | (true, None, _) => Fetching
+    | (false, _, Some(error)) => Error(error)
     | (true, Some(data), _) => Data(data)
     | (false, Some(data), _) => Data(data)
-    | (false, _, Some(error)) => Error(error)
     | (false, None, None) => NotFound
     };
 


### PR DESCRIPTION
During the conversion from JS response to record, the `Data` branch is checked before the `Error` branch, but it's to my understanding that there can't be `Data` when the server returns a graphql error (Instead of an error in the schema)