### PR TITLE
Make bs-fetch a peerDependency.

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -23,7 +23,7 @@
   ],
   "suffix": ".bs.js",
   "namespace": false,
-  "bs-dependencies": ["reason-react", "bs-fetch", "wonka"],
+  "bs-dependencies": ["reason-react", "wonka", "bs-fetch"],
   "bs-dev-dependencies": ["@glennsl/bs-jest"],
   "refmt": 3,
   "warnings": {

--- a/examples/1-execute-query-mutation/yarn.lock
+++ b/examples/1-execute-query-mutation/yarn.lock
@@ -651,11 +651,6 @@ bs-css@^8.0.2:
   dependencies:
     emotion "^9.2.12"
 
-bs-fetch@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.1.tgz#9c7d074b27e6bb2b9f2ec985964f32bcac49f79e"
-  integrity sha512-MxwnuuXPldXnoCtlpeN5JNbbmb1tVgsqpLfVunvuMLAIQNyP0TqoImHiQRTz38PBSN8/iX+2yVlm+PFJfnHHiA==
-
 bs-platform@5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"

--- a/examples/2-query/yarn.lock
+++ b/examples/2-query/yarn.lock
@@ -676,11 +676,6 @@ bs-css@^8.0.4:
   dependencies:
     emotion "^9.2.12"
 
-bs-fetch@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.1.tgz#9c7d074b27e6bb2b9f2ec985964f32bcac49f79e"
-  integrity sha512-MxwnuuXPldXnoCtlpeN5JNbbmb1tVgsqpLfVunvuMLAIQNyP0TqoImHiQRTz38PBSN8/iX+2yVlm+PFJfnHHiA==
-
 bs-platform@5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"

--- a/examples/3-mutation/yarn.lock
+++ b/examples/3-mutation/yarn.lock
@@ -661,11 +661,6 @@ bs-css@^8.0.2:
   dependencies:
     emotion "^9.2.12"
 
-bs-fetch@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.1.tgz#9c7d074b27e6bb2b9f2ec985964f32bcac49f79e"
-  integrity sha512-MxwnuuXPldXnoCtlpeN5JNbbmb1tVgsqpLfVunvuMLAIQNyP0TqoImHiQRTz38PBSN8/iX+2yVlm+PFJfnHHiA==
-
 bs-platform@5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"

--- a/examples/4-exchanges/yarn.lock
+++ b/examples/4-exchanges/yarn.lock
@@ -651,11 +651,6 @@ bs-css@^8.0.4:
   dependencies:
     emotion "^9.2.12"
 
-bs-fetch@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.1.tgz#9c7d074b27e6bb2b9f2ec985964f32bcac49f79e"
-  integrity sha512-MxwnuuXPldXnoCtlpeN5JNbbmb1tVgsqpLfVunvuMLAIQNyP0TqoImHiQRTz38PBSN8/iX+2yVlm+PFJfnHHiA==
-
 bs-platform@5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"

--- a/examples/5-subscription/src/app/bindings/SubscriptionsTransportWS.re
+++ b/examples/5-subscription/src/app/bindings/SubscriptionsTransportWS.re
@@ -29,7 +29,9 @@ type client = {
   [@bs.meth]
   "request":
     UrqlClient.UrqlExchanges.subscriptionOperation =>
-    UrqlClient.UrqlExchanges.observableLike(UrqlClient.Types.executionResult),
+    UrqlClient.UrqlExchanges.observableLike(
+      UrqlClient.ClientTypes.executionResult,
+    ),
 };
 
 [@bs.new] [@bs.module "subscriptions-transport-ws"]

--- a/examples/5-subscription/yarn.lock
+++ b/examples/5-subscription/yarn.lock
@@ -995,11 +995,6 @@ bs-css@^8.0.2:
   dependencies:
     emotion "^9.2.12"
 
-bs-fetch@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.1.tgz#9c7d074b27e6bb2b9f2ec985964f32bcac49f79e"
-  integrity sha512-MxwnuuXPldXnoCtlpeN5JNbbmb1tVgsqpLfVunvuMLAIQNyP0TqoImHiQRTz38PBSN8/iX+2yVlm+PFJfnHHiA==
-
 bs-platform@5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "bs-fetch": "^0.3.0",
     "graphql": "^14.1.1",
     "urql": "1.0.5",
     "wonka": "^3.1.0"
@@ -33,6 +32,7 @@
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.8",
     "all-contributors-cli": "^5.4.0",
+    "bs-fetch": "^0.5.0",
     "bs-platform": "5.0.4",
     "graphql_ppx": "^0.2.7",
     "husky": "^2.4.1",
@@ -40,6 +40,7 @@
     "reason-react": "0.7.0"
   },
   "peerDependencies": {
+    "bs-fetch": "^0.5.0",
     "graphql_ppx": "^0.2.7",
     "reason-react": "0.7.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,10 +700,10 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
-bs-fetch@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.3.1.tgz#9c7d074b27e6bb2b9f2ec985964f32bcac49f79e"
-  integrity sha512-MxwnuuXPldXnoCtlpeN5JNbbmb1tVgsqpLfVunvuMLAIQNyP0TqoImHiQRTz38PBSN8/iX+2yVlm+PFJfnHHiA==
+bs-fetch@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.5.0.tgz#6913b1d1ddfa0b0a4b832357854e9763d61d4b28"
+  integrity sha512-cGjwRpyNcIaX+p2ssy/38zs7BM/miKNgmOR3NEhxKFete5mR05JcvjuV4raG89oGCG281SU1b56TTAKmf9VCug==
 
 bs-platform@5.0.4:
   version "5.0.4"


### PR DESCRIPTION
This PR attempts to make `bs-fetch` a `peerDependency` for `reason-urql`. `bs-fetch` is solely used to type a few fields on the `Client` and the `combinedError`, but otherwise isn't actually used. It needs to be there to support the compiler in these modules, but in order to prevent our dep from conflicting with a user's own version of `bs-fetch`, we don't want to actually ship our dependency on `bs-fetch`.

cc/ @gugahoa I haven't yet ported this over to the examples, but let me know if you're able to apply this patch to see if it can help fix your issues! I think it'd be a win for the lib overall if we could remove this dependency. Will follow up on the examples tomorrow, just a bit late here in London!