### PR TITLE
Expose message field on combinedError

### DIFF
--- a/src/utils/UrqlCombinedError.re
+++ b/src/utils/UrqlCombinedError.re
@@ -55,6 +55,7 @@ class type _combinedError =
     pub networkError: Js.Nullable.t(Js.Exn.t);
     pub graphqlErrors: Js.Nullable.t(array(graphqlError));
     pub response: Js.Nullable.t(Fetch.response);
+    pub message: string;
   };
 
 type t = Js.t(_combinedError);
@@ -63,6 +64,7 @@ type combinedError = {
   networkError: option(Js.Exn.t),
   graphqlErrors: option(array(graphqlError)),
   response: option(Fetch.response),
+  message: string,
 };
 
 let combinedErrorToRecord = (err: t): combinedError => {
@@ -70,6 +72,7 @@ let combinedErrorToRecord = (err: t): combinedError => {
     networkError: err##networkError->Js.Nullable.toOption,
     graphqlErrors: err##graphqlErrors->Js.Nullable.toOption,
     response: err##response->Js.Nullable.toOption,
+    message: err##message,
   };
 };
 


### PR DESCRIPTION
Hacked-together PR to expose the message field from the urql combinederror object https://github.com/FormidableLabs/urql/blob/6e0e6557b487bc2c416215a9c92cce809b8bf9df/src/utils/error.ts#L64

Might still need to test this out but I wanted to get someone's opinion on the idea.

A couple times I've wanted to just quickly log the error without needing to handle all the cases/formatting etc. In the past I've made the mistake of  just `Js.String.make`ing the error, but that just gives some `[object Object]`-style output because urql defines the toString on their error object but we convert it to a record, which doesn't have the custom toString unfortunately. I looked into exposing the toString for the record version, but then realized that all the toString does is return the `message` field anyway so we might as well expose that directly?