### PR TITLE
FIx capitalization in CombinedError bindings

### DIFF
--- a/src/utils/UrqlCombinedError.re
+++ b/src/utils/UrqlCombinedError.re
@@ -53,7 +53,7 @@ class type _combinedError =
   [@bs]
   {
     pub networkError: Js.Nullable.t(Js.Exn.t);
-    pub graphqlErrors: Js.Nullable.t(array(graphqlError));
+    pub graphQLErrors: Js.Nullable.t(array(graphqlError));
     pub response: Js.Nullable.t(Fetch.response);
     pub message: string;
   };
@@ -70,7 +70,7 @@ type combinedError = {
 let combinedErrorToRecord = (err: t): combinedError => {
   {
     networkError: err##networkError->Js.Nullable.toOption,
-    graphqlErrors: err##graphqlErrors->Js.Nullable.toOption,
+    graphqlErrors: err##graphQLErrors->Js.Nullable.toOption,
     response: err##response->Js.Nullable.toOption,
     message: err##message,
   };


### PR DESCRIPTION
Right now this is always null, since we don't match https://github.com/FormidableLabs/urql/blob/f4b11379e43ef14bbc2a5bf563a6aa2cc09b4271/src/utils/error.ts#L43

Probably we should also update `graphqlErrors` in the record to match, but since that's a breaking change, I thought it might be best done as part of something in #106?