### PR TITLE
Update CombinedError API to expose the combinedError record as the core module type t.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -740,7 +740,16 @@ In this case, `networkError` returns the original JavaScript error thrown if a n
 
 #### Example
 
-Dependening on the types of errors you get from your GraphQL API, you may want to do different things. Here's an example showing how to handle `networkError`s and `graphQLErrors` separately.
+The easiest way to interact with `CombinedError` is through the `message` field on the `CombinedError.t` record. If you just want to display the error message to your user, or operate directly on the error string, simply do the following:
+
+```reason
+switch (response) {
+  | Error(e) => <div> e.message->React.string </div>
+  | _ => <div />
+}
+```
+
+Dependening on the types of errors you get from your GraphQL API, you may want to do different things. Here's an example showing how to handle `networkError`s and `graphQLErrors` indepedently.
 
 ```reason
 let ({ response }, _) = useQuery(~request, ());
@@ -773,15 +782,6 @@ switch (response) {
     | _ => <div> "Unknown error."->React.string </div>
     }
   }
-  | _ => <div />
-}
-```
-
-Due to the verbosity of the above, sometimes it isn't useful to handle every potential case around errors in your application. When you just want a simple error message of what went wrong to display to the user, just access the `message` field on the `CombinedError.t`:
-
-```reason
-switch (response) {
-  | Error(e) => <div> e.message->React.string </div>
   | _ => <div />
 }
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -722,3 +722,66 @@ let client = Client.make(
 #### `composeExchanges`
 
 `composeExchanges` is a helper function that will compose a single exchange from an array of exchanges. Operations will be run through the provided exchanges in the order that they were provided to `composeExchanges`, from left to right.
+
+## `CombinedError`
+
+Errors in `reason-urql` are handed to your components and hooks via a record of type `CombinedError.t`. The record has the following type:
+
+```reason
+type combinedError = {
+  networkError: option(Js.Exn.t),
+  graphQLErrors: option(array(graphQLError)),
+  response: option(Fetch.response),
+  message: string,
+};
+```
+
+In this case, `networkError` returns the original JavaScript error thrown if a network error was encountered. `graphQLErrors` represent an `array` of errors of type `graphQLError`. These represent the errors encountered in the validation or execution stages of interacting with your GraphQL API. `response` is the raw `response` object returned by `fetch`. `message` is a stringified version of either the `networkError` or the `graphQLErrors` – `networkError` will take precedence.
+
+#### Example
+
+Dependening on the types of errors you get from your GraphQL API, you may want to do different things. Here's an example showing how to handle `networkError`s and `graphQLErrors` separately.
+
+```reason
+let ({ response }, _) = useQuery(~request, ());
+
+switch (response) {
+  | Error(e) =>
+    switch (e) {
+    | {networkError: Some(ne)} =>
+      <div>
+        {ne
+        ->Js.Exn.message
+        ->Belt.Option.getWithDefault("Network error")
+        ->React.string}
+      </div>
+    | {graphQLErrors: Some(gqle)} =>
+      <div>
+        {gqle
+        |> Array.to_list
+        |> List.map(e => {
+              let msg =
+                Belt.Option.getWithDefault(
+                  Js.Nullable.toOption(CombinedError.messageGet(e)),
+                  "GraphQL error",
+                );
+              "[GraphQLError: " ++ msg ++ "]";
+            })
+        |> String.concat(", ")
+        |> React.string}
+      </div>
+    | _ => <div> "Unknown error."->React.string </div>
+    }
+  }
+  | _ => <div />
+}
+```
+
+Due to the verbosity of the above, sometimes it isn't useful to handle every potential case around errors in your application. When you just want a simple error message of what went wrong to display to the user, just access the `message` field on the `CombinedError.t`:
+
+```reason
+switch (response) {
+  | Error(e) => <div> e.message->React.string </div>
+  | _ => <div />
+}
+```

--- a/examples/2-query/src/index.re
+++ b/examples/2-query/src/index.re
@@ -51,7 +51,32 @@ ReactDOMRe.renderToElementWithId(
              | None => <div> "No Data"->React.string </div>
              }
            | Fetching => <div> "Loading"->React.string </div>
-           | Error(_e) => <div> "Error!"->React.string </div>
+           | Error(e) =>
+             switch (e) {
+             | {networkError: Some(ne)} =>
+               <div>
+                 {ne
+                  ->Js.Exn.message
+                  ->Belt.Option.getWithDefault("Network error")
+                  ->React.string}
+               </div>
+             | {graphQLErrors: Some(gqle)} =>
+               <div>
+                 {gqle
+                  |> Array.to_list
+                  |> List.map(e => {
+                       let msg =
+                         Belt.Option.getWithDefault(
+                           Js.Nullable.toOption(CombinedError.messageGet(e)),
+                           "GraphQL error",
+                         );
+                       "[GraphQLError: " ++ msg ++ "]";
+                     })
+                  |> String.concat(", ")
+                  |> React.string}
+               </div>
+             | _ => <div> "Unknown error."->React.string </div>
+             }
            | NotFound => <div> "Not Found"->React.string </div>
            }}
         </main>

--- a/examples/4-exchanges/src/index.re
+++ b/examples/4-exchanges/src/index.re
@@ -56,16 +56,13 @@ executeQuery(~client, ~request=queryRequest, ())
      switch (data.response) {
      | Data(d) =>
        Js_global.setInterval(
-         () =>
-           switch (d##dogs) {
-           | Some(dogs) =>
-             dogs->Belt.Array.shuffleInPlace;
-             let mutationRequest = LikeDog.make(~key=dogs[0]##key, ());
-             executeMutation(~client, ~request=mutationRequest, ())
-             |> Wonka.subscribe((. response) => Js.log(response))
-             |> ignore;
-           | None => ()
-           },
+         () => {
+           d##dogs->Belt.Array.shuffleInPlace;
+           let mutationRequest = LikeDog.make(~key=d##dogs[0]##key, ());
+           executeMutation(~client, ~request=mutationRequest, ())
+           |> Wonka.subscribe((. response) => Js.log(response))
+           |> ignore;
+         },
          5000,
        )
        |> ignore

--- a/src/ReasonUrql.re
+++ b/src/ReasonUrql.re
@@ -25,7 +25,7 @@ module SubscriptionWithHandler = UrqlSubscription.SubscriptionWithHandler;
 
 module Request = UrqlRequest;
 
-module Error = UrqlCombinedError;
+module CombinedError = UrqlCombinedError;
 
 module Exchanges = UrqlClient.UrqlExchanges;
 

--- a/src/UrqlClient.re
+++ b/src/UrqlClient.re
@@ -20,7 +20,7 @@ module ClientTypes = {
      Consists of optional data and errors fields. */
   [@bs.deriving abstract]
   type executionResult = {
-    errors: Js.Nullable.t(array(UrqlCombinedError.graphqlError)),
+    errors: Js.Nullable.t(array(UrqlCombinedError.graphQLError)),
     data: Js.Nullable.t(Js.Json.t),
   };
 
@@ -73,7 +73,7 @@ module ClientTypes = {
   type operationResult = {
     operation,
     data: Js.Nullable.t(Js.Json.t),
-    error: Js.Nullable.t(UrqlCombinedError.t),
+    error: Js.Nullable.t(UrqlCombinedError.combinedErrorJs),
   };
 
   /* The record representing the response returned by the client _after_

--- a/src/UrqlTypes.re
+++ b/src/UrqlTypes.re
@@ -46,5 +46,5 @@ type jsResponse = {
   [@bs.as "data"]
   jsData: Js.Nullable.t(Js.Json.t),
   [@bs.optional] [@bs.as "error"]
-  jsError: UrqlCombinedError.t,
+  jsError: UrqlCombinedError.combinedErrorJs,
 };

--- a/src/components/UrqlMutation.re
+++ b/src/components/UrqlMutation.re
@@ -2,7 +2,7 @@
 type mutationRenderPropsJs = {
   fetching: bool,
   data: Js.Nullable.t(Js.Json.t),
-  error: Js.Nullable.t(UrqlCombinedError.t),
+  error: Js.Nullable.t(UrqlCombinedError.combinedErrorJs),
   executeMutation:
     option(Js.Json.t) => Js.Promise.t(UrqlClient.ClientTypes.operationResult),
 };

--- a/src/components/UrqlQuery.re
+++ b/src/components/UrqlQuery.re
@@ -2,7 +2,7 @@
 type queryRenderPropsJs = {
   fetching: bool,
   data: Js.Nullable.t(Js.Json.t),
-  error: Js.Nullable.t(UrqlCombinedError.t),
+  error: Js.Nullable.t(UrqlCombinedError.combinedErrorJs),
   executeQuery:
     option(Js.Json.t) => Js.Promise.t(UrqlClient.ClientTypes.operationResult),
 };

--- a/src/components/UrqlSubscription.re
+++ b/src/components/UrqlSubscription.re
@@ -5,7 +5,7 @@ type subscriptionRenderPropsJs('ret) = {
   fetching: bool,
   data: Js.Nullable.t('ret),
   [@bs.optional]
-  error: UrqlCombinedError.t,
+  error: UrqlCombinedError.combinedErrorJs,
 };
 
 type subscriptionRenderProps('ret) = {

--- a/src/hooks/UrqlUseSubscription.re
+++ b/src/hooks/UrqlUseSubscription.re
@@ -16,7 +16,7 @@ type useSubscriptionResponseJs('ret) = {
   fetching: bool,
   data: Js.Nullable.t('ret),
   [@bs.optional]
-  error: UrqlCombinedError.t,
+  error: UrqlCombinedError.combinedErrorJs,
 };
 
 [@bs.module "urql"]

--- a/src/utils/UrqlCombinedError.re
+++ b/src/utils/UrqlCombinedError.re
@@ -38,7 +38,7 @@ type extension;
     https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/graphql/error/GraphQLError.d.ts.
    */
 [@bs.deriving abstract]
-type graphqlError = {
+type graphQLError = {
   message: Js.Nullable.t(message),
   locations: Js.Nullable.t(locations),
   path: Js.Nullable.t(array(path)),
@@ -53,27 +53,28 @@ class type _combinedError =
   [@bs]
   {
     pub networkError: Js.Nullable.t(Js.Exn.t);
-    pub graphQLErrors: Js.Nullable.t(array(graphqlError));
+    pub graphQLErrors: Js.Nullable.t(array(graphQLError));
     pub response: Js.Nullable.t(Fetch.response);
     pub message: string;
   };
 
-type t = Js.t(_combinedError);
+type combinedErrorJs = Js.t(_combinedError);
+[@bs.module "urql"] external combinedError: combinedErrorJs = "CombinedError";
 
 type combinedError = {
   networkError: option(Js.Exn.t),
-  graphqlErrors: option(array(graphqlError)),
+  graphQLErrors: option(array(graphQLError)),
   response: option(Fetch.response),
   message: string,
 };
 
-let combinedErrorToRecord = (err: t): combinedError => {
+let combinedErrorToRecord = (err: combinedErrorJs): combinedError => {
   {
     networkError: err##networkError->Js.Nullable.toOption,
-    graphqlErrors: err##graphQLErrors->Js.Nullable.toOption,
+    graphQLErrors: err##graphQLErrors->Js.Nullable.toOption,
     response: err##response->Js.Nullable.toOption,
     message: err##message,
   };
 };
 
-[@bs.module "urql"] external combinedError: t = "CombinedError";
+type t = combinedError;


### PR DESCRIPTION
Fix #106 

This PR updates our `CombinedError` API to pass the `combinedError` record as the module type `t` that users will interact with. This feels more ergonomic to me and I believe @Schmavery felt the same. I also added the beginnings of docs on how to use `CombinedError`. I decided it wasn't useful to add a `.rei` file for this module b/c it is full of a bunch of BuckleScript accessors generated by all the `[@bs.deriving abstract]`, and we basically want the entirety of the module public anyway.

In terms of how we want to release this, I'm a little torn. It is a small breaking change that will (I suspect) break folks' builds, but it also feels fairly minimal. I'm inclined to release it as a minor (`v1.1.0`) but could also consider a patch (`v1.0.2`) if others feel that works better. cc/ @Schmavery @gugahoa let me know your thoughts here. @Schmavery I co-authored you on the commit by the way, since I slightly modified the error modifier you have on Coda for the example here (it's really nice btw, love it).