### PR TITLE
Run all examples through bsb in CI.

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           yarn
           yarn build
-          cd examples
-          for dir in ./examples/*; do (cd "$dir"; yarn; yarn build; cd ../); done
+          cd $GITHUB_WORKSPACE/examples
+          for dir in $GITHUB_WORKSPACE/examples/*; do (cd "$dir"; yarn; yarn build; cd ../); done
         env:
           CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -12,15 +11,36 @@ jobs:
         node-version: [8.x, 10.x, 12.x]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Build and Test
-      run: |
-        yarn
-        yarn build
-        yarn test
-      env:
-        CI: true
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Build and Test
+        run: |
+          yarn
+          yarn build
+          yarn test
+        env:
+          CI: true
+  build-examples:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Build Examples
+        run: |
+          yarn
+          yarn build
+          cd examples
+          for dir in ./examples/*; do (cd "$dir"; yarn; yarn build; cd ../); done
+        env:
+          CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,6 +41,6 @@ jobs:
           yarn
           yarn build
           cd $GITHUB_WORKSPACE/examples
-          for dir in $GITHUB_WORKSPACE/examples/*; do (cd "$dir"; yarn; yarn build; cd ../); done
+          for dir in $GITHUB_WORKSPACE/examples/*; do (cd "$dir"; yarn; yarn clean; yarn build; cd ../); done
         env:
           CI: true


### PR DESCRIPTION
This PR would add a step to our CI process to run each example in our `examples` directory through `bsb`, the BuckleScript compiler, to ensure that the examples still compile with the latest changes from `src`. This would remove a lot of overhead from manually checking that examples still compile on every change we make.

I am a little concerned that the script I have could potentially be a bit flaky – looping through directories like this seems potentially brittle, so I'd love to hear thoughts on a better way to accomplish this if anyone has ideas! We need to enforce that the root `src` directory is compiled first, but after that the examples can be compiled in parallel / order independent. @ryan-roemer tagging you for your CI wisdom.