### PR TITLE
Add bindings for ssrExchange. Upgrade to urql 1.1.3.

### DIFF
--- a/__tests__/UrqlClient_test.re
+++ b/__tests__/UrqlClient_test.re
@@ -116,4 +116,64 @@ describe("UrqlClient", () => {
       )
     );
   });
+
+  describe("ssrExchange", () => {
+    it("should exist and be callable", () =>
+      Expect.(expect(Exchanges.ssrExchange()) |> toMatchSnapshot)
+    );
+
+    it(
+      "should accept an initialState for passing data extracted during SSR prepass",
+      () => {
+      let json = Js.Dict.empty();
+      Js.Dict.set(json, "key", Js.Json.number(1.));
+      Js.Dict.set(json, "key2", Js.Json.number(2.));
+      let data = Js.Json.object_(json);
+      let serializedResult = Exchanges.serializedResult(~data, ());
+
+      let initialState = Js.Dict.empty();
+      Js.Dict.set(initialState, "query", serializedResult);
+      let ssrExchangeOpts = Exchanges.ssrExchangeOpts(~initialState, ());
+
+      Expect.(
+        expect(() =>
+          Exchanges.ssrExchange(~ssrExchangeOpts, ())
+        )
+        |> not
+        |> toThrow
+      );
+      /* let ssrCache = Exchanges.ssrExchange(~ssrExchangeOpts, ());
+         let decodedResult =
+           Exchanges.extractData(~exchange=ssrCache) |> Js.Json.decodeObject;
+
+         switch (decodedResult) {
+         | Some(dict) =>
+           let result = (
+             Js.Dict.unsafeGet(dict, "key") |> Js.Json.decodeNumber,
+             Js.Dict.unsafeGet(dict, "key2") |> Js.Json.decodeNumber,
+           );
+           Expect.(expect(result) |> toEqual((Some(1.), Some(2.))));
+         | None => Expect.(expect(1) |> toEqual(1))
+         }; */
+    });
+
+    it(
+      "should expose a restoreData method for rehydrating data fetched server-side on the client",
+      () => {
+        let json = Js.Dict.empty();
+        Js.Dict.set(json, "key", Js.Json.number(1.));
+        Js.Dict.set(json, "key2", Js.Json.number(2.));
+        let data = Js.Json.object_(json);
+        let ssrCache = Exchanges.ssrExchange();
+
+        Expect.(
+          expect(() =>
+            Exchanges.restoreData(~exchange=ssrCache, ~restore=data)
+          )
+          |> not
+          |> toThrow
+        );
+      },
+    );
+  });
 });

--- a/__tests__/UrqlClient_test.re
+++ b/__tests__/UrqlClient_test.re
@@ -142,19 +142,20 @@ describe("UrqlClient", () => {
         |> not
         |> toThrow
       );
-      /* let ssrCache = Exchanges.ssrExchange(~ssrExchangeOpts, ());
-         let decodedResult =
-           Exchanges.extractData(~exchange=ssrCache) |> Js.Json.decodeObject;
+    });
 
-         switch (decodedResult) {
-         | Some(dict) =>
-           let result = (
-             Js.Dict.unsafeGet(dict, "key") |> Js.Json.decodeNumber,
-             Js.Dict.unsafeGet(dict, "key2") |> Js.Json.decodeNumber,
-           );
-           Expect.(expect(result) |> toEqual((Some(1.), Some(2.))));
-         | None => Expect.(expect(1) |> toEqual(1))
-         }; */
+    it(
+      "should expose an extractData method for extracting server-side rendered data",
+      () => {
+      let ssrCache = Exchanges.ssrExchange();
+
+      Expect.(
+        expect(() =>
+          Exchanges.extractData(~exchange=ssrCache)
+        )
+        |> not
+        |> toThrow
+      );
     });
 
     it(

--- a/__tests__/__snapshots__/UrqlClient_test.bs.js.snap
+++ b/__tests__/__snapshots__/UrqlClient_test.bs.js.snap
@@ -14,6 +14,7 @@ Client {
   "operations$": [Function],
   "reexecuteOperation": [Function],
   "results$": [Function],
+  "suspense": false,
   "url": "https://localhost:3000",
 }
 `;
@@ -32,6 +33,7 @@ Client {
   "operations$": [Function],
   "reexecuteOperation": [Function],
   "results$": [Function],
+  "suspense": false,
   "url": "https://localhost:3000",
 }
 `;
@@ -57,6 +59,7 @@ Client {
   "operations$": [Function],
   "reexecuteOperation": [Function],
   "results$": [Function],
+  "suspense": false,
   "url": "https://localhost:3000",
 }
 `;
@@ -75,6 +78,9 @@ Client {
   "operations$": [Function],
   "reexecuteOperation": [Function],
   "results$": [Function],
+  "suspense": false,
   "url": "https://localhost:3000",
 }
 `;
+
+exports[`UrqlClient ssrExchange should exist and be callable 1`] = `[Function]`;

--- a/docs/api.md
+++ b/docs/api.md
@@ -490,6 +490,7 @@ Instantiate an `urql` client instance. By default, `urql` will execute requests 
 | `url`          | `string`                              | The url of your GraphQL API.                                                                                                                                                                                                                                 |
 | `fetchOptions` | `option(Client.fetchOptions)=?`       | A variant type representing optional fetch options to be used by your client. You can pass your `fetchOptions` as a plain `Fetch.requestInit` by wrapping it in `Client.FetchOpts`, or instantiate it dynamically in a function wrapped by `Client.FetchFn`. |
 | `exchanges`    | `option(array(Exchanges.exchange))=?` | The array of exchanges to be used by your client.                                                                                                                                                                                                            |
+| `suspense`     | `option(bool)=false`                  | A flag activating the experimental React suspense mode, which can be used during server-side rendering to prefetch data.                                                                                                                                     |
 
 #### Return Type
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -443,13 +443,13 @@ let make = () => {
 
 ### `Provider`
 
-The `Provider`'s responsibility is to pass the `urql` client instance down to `Query`, `Mutation`, and `Subscription` components through context. Wrap the root of your application with `Provider`.
+The `Provider`'s responsibility is to pass the `urql` client instance down to `Query`, `Mutation`, and `Subscription` components or `useQuery`, `useMutation`, and `useSubcription` hooks through context. Wrap the root of your application with `Provider`.
 
 #### Props
 
-| Prop     | Type       | Description                 |
-| -------- | ---------- | --------------------------- |
-| `client` | `Client.t` | The `urql` client instance. |
+| Prop    | Type       | Description                 |
+| ------- | ---------- | --------------------------- |
+| `value` | `Client.t` | The `urql` client instance. |
 
 #### Example
 
@@ -659,11 +659,11 @@ Client.executeSubscription(~client, ~request, ())
 
 Exchanges are the mechanism by which `urql` modifies requests before they are sent to your GraphQL API and alters responses as they are received. If you want to add some additional functionality to your GraphQL operations, this is a great place to do that. The following exchanges are provided out of the box with `urql`.
 
-#### cacheExchange
+#### `cacheExchange`
 
 The `cacheExchange` provides basic caching support for your GraphQL operations. It is of type `Exchanges.exchange`.
 
-#### dedupExchange
+#### `dedupExchange`
 
 The `dedupExchange` will deduplicate pending operations waiting for a response. For example, if a user attempts to execute the same query by clicking a button in rapid succession, the `dedupExchange` will filter these events to a single request. It is of type `Exchanges.exchange`.
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "graphql": "^14.1.1",
-    "urql": "1.0.5",
+    "urql": "1.1.3",
     "wonka": "^3.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,11 +339,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/fast-json-stable-stringify@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#40363bb847cb86b2c2e1599f1398d11e8329c921"
-  integrity sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ==
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -543,11 +538,6 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
-
 asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
@@ -709,11 +699,6 @@ bs-platform@5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"
   integrity sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==
-
-bs-rebel@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/bs-rebel/-/bs-rebel-0.2.3.tgz#11e1a95a4a3f16311575e8853a004cec6b9d19de"
-  integrity sha512-NTDUSkJ+KkIqmKHUE48luD2YaYh49XaU1zVSSk9lJ6KFNQzlRQnIfR+paNWYyvzxf5+TZ2inVgxBUHdCsZEiYA==
 
 bser@^2.0.0:
   version "2.0.0"
@@ -931,11 +916,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -950,14 +930,6 @@ cosmiconfig@^5.2.0:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
-
-create-react-context@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
-  integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
-  dependencies:
-    fbjs "^0.8.0"
-    gud "^1.0.0"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -1143,13 +1115,6 @@ elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
-
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
 
 end-of-stream@^1.1.0:
   version "1.4.1"
@@ -1358,19 +1323,6 @@ fb-watchman@^2.0.0:
   integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
   dependencies:
     bser "^2.0.0"
-
-fbjs@^0.8.0:
-  version "0.8.17"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
-  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
 
 figures@^1.7.0:
   version "1.7.0"
@@ -1595,11 +1547,6 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
-  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
-
 handlebars@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
@@ -1721,7 +1668,7 @@ husky@^2.4.1:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -1996,7 +1943,7 @@ is-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
   integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -2044,14 +1991,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -2986,14 +2925,6 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -3455,13 +3386,6 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
   integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
 prompts@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.1.0.tgz#bf90bc71f6065d255ea2bdc0fe6520485c1b45db"
@@ -3849,11 +3773,6 @@ set-value@^2.0.0:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
-
-setimmediate@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
-  integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -4297,11 +4216,6 @@ type-fest@^0.4.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.4.1.tgz#8bdf77743385d8a4f13ba95f610f5ccd68c728f8"
   integrity sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==
 
-ua-parser-js@^0.7.18:
-  version "0.7.20"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
-  integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
-
 uglify-js@^3.1.4:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
@@ -4340,17 +4254,15 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-urql@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-1.0.5.tgz#782b6477692679e871cb55aa380e81f3746e053a"
-  integrity sha512-HIdfzxMC14ryyztakAxgKNEma4eC2N7iZaebLirslIiZAE+QLN5PoS0t30sfi9uG3ks0V9Y/AJRh2Du05g+8Mg==
+urql@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-1.1.3.tgz#41fffb0a3b1a3f7ac47be55b7f84ca69875e7358"
+  integrity sha512-H6xdtT+b3n7OYG1U/ItLHTBfBpM0Kxd6FkQSYP1TvylqUeyz160whRu/XpwDRt2VwbLy5+j729wv4BF1f1zP4Q==
   dependencies:
-    "@types/fast-json-stable-stringify" "^2.0.0"
-    create-react-context "^0.2.3"
     fast-json-stable-stringify "^2.0.0"
     graphql-tag "^2.10.1"
     prop-types "^15.6.0"
-    wonka "^2.0.1"
+    wonka "^3.0.0"
 
 use@^3.1.0:
   version "3.1.1"
@@ -4418,11 +4330,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@>=0.10.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
-
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
@@ -4465,14 +4372,7 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2 || 2"
 
-wonka@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/wonka/-/wonka-2.0.2.tgz#6523631a0121b92f2ee5b95971a16335d1985e43"
-  integrity sha512-xbWQpBlBOaNUeZj7IsgXMwE08HeomMQYkaUVoXIHgyAOk9bdfqOA9Ccw87cL1jgFbGOeXifO9OfgeL6vut9/8Q==
-  dependencies:
-    bs-rebel "^0.2.3"
-
-wonka@^3.1.0:
+wonka@^3.0.0, wonka@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/wonka/-/wonka-3.2.1.tgz#f66123fabbb260f23a4e89f1526317169203e258"
   integrity sha512-LpquZ9PJtYJ31AlMPp5tEba1y+S+wUmY7OyFLGZCmGSNO1ZOTTZGp/HbieFzP5fVJ9fWXCus3ecgDjwAssHSGg==


### PR DESCRIPTION
This PR adds bindings for the `ssrExchange` to `reason-urql` and upgrades our `urql` dependency to 1.1.3 🎉 This will form the basis of our 1.1.0 release.

While binding this exchange didn't prove to be too difficult, getting a working example with NextJS was non-trivial. For the time being, I decided to skip it. A few things make this really hard:

- The need for a server-side prepass step. I was actually able to successfully bind this: https://github.com/FormidableLabs/bs-react-ssr-prepass. However, the below considerations pushed this over the edge of feasibility currently.
- The need for a higher order component to run the prepass step. Implementing HoCs in Reason is a fairly well known issue and I've never really been able to do it. This is the HoC we'd need to re-implement: https://github.com/FormidableLabs/urql/blob/master/examples/3-ssr-with-nextjs/src/with-urql-client.js Conversely, binding HoCs is possible, and I have an [RFC open](https://github.com/FormidableLabs/urql/issues/452) to create a `next-urql` package that we'd be able to bind to 🎉 This should make things much easier in the near future, but also make our own support for the `ssrExchange` a bit moot.
- General problems with having this example in source i.e. challenges with ES6 vs. CommonJs compilation and BuckleScript's weirdness around ES Modules and default imports / exports.

I don't want this feature to hold up development on other parts of `reason-urql`, so for now I've exposed the bindings and curious souls can venture forth with them if they want to!

@kitten I'd love any thoughts you might have on the above or feelings around how to make SSR easier here. Tagging @Schmavery and @gugahoa as well for visibility.