### PR TITLE
docs: Add bs-fetch peer dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Reason bindings for Formidable's Universal React Query Library, [`urql`](https:/
 
 ## 💾 Installation
 
-#### 1. Install `reason-urql`.
+#### 1. Install `reason-urql` & `bs-fetch` peer dependency.
 
 ```sh
-yarn add reason-urql
+yarn add reason-urql bs-fetch
 ```
 
 #### 2. Add `graphql_ppx`.


### PR DESCRIPTION
After FormidableLabs#104 was merged, you have to explicitly install bs-fetch which may not be obvious to everyone until you try to compile and it fails:

```bash
File "bsconfig.json", line 1
Error: package bs-fetch not found or built 
- Did you install it?
- If you did, did you run `bsb -make-world`?
error Command failed with exit code 2.
```

So to avoid any friction in installing the library I think it's preferable to make this explicit in step 1 such that you are not met with the error when you try to compile.