### PR TITLE
Fix #122 and #123

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,14 +34,12 @@
     "all-contributors-cli": "^5.4.0",
     "bs-fetch": "^0.5.0",
     "bs-platform": "5.2.1",
-    "graphql_ppx": "^0.2.7",
     "husky": "^2.4.1",
     "lint-staged": "^8.2.1",
     "reason-react": "0.7.0"
   },
   "peerDependencies": {
     "bs-fetch": "^0.5.0",
-    "graphql_ppx": "^0.2.7",
     "reason-react": "0.7.0"
   },
   "jest": {

--- a/src/components/UrqlQuery.re
+++ b/src/components/UrqlQuery.re
@@ -23,7 +23,7 @@ module QueryJs = {
       ~query: string,
       ~variables: Js.Json.t,
       ~requestPolicy: string,
-      ~pause: option(bool)=?,
+      ~pause: bool=?,
       ~children: queryRenderPropsJs => React.element
     ) =>
     React.element =
@@ -68,7 +68,7 @@ let make =
     query
     variables
     requestPolicy={UrqlTypes.requestPolicyToJs(requestPolicy)}
-    pause>
+    ?pause>
     {result => result |> urqlQueryResponseToReason(parse) |> children}
   </QueryJs>;
 };


### PR DESCRIPTION
This change makes it possible to use `reason-urql` in projects which uses `bs-platform` 6.2.1