### PR TITLE
Add functor API for hooks.

### DIFF
--- a/examples/3-mutation/src/Dog.re
+++ b/examples/3-mutation/src/Dog.re
@@ -68,8 +68,8 @@ let make =
   let (_, executeLikeMutation) =
     useMutation(~request=Mutations.LikeDog.make(~key=id, ()));
 
-  module TreatMutationDog = UrqlUseMutation.Make(Mutations.TreatDog);
-  let (_, executeTreatMutation) = TreatMutationDog.useMutation();
+  module TreatDogMutation = UrqlUseMutation.Make(Mutations.TreatDog);
+  let (_, executeTreatMutation) = TreatDogMutation.useMutation();
 
   <div className=DogStyles.container>
     <img src=imageUrl alt=name className=DogStyles.image />

--- a/examples/3-mutation/src/Dog.re
+++ b/examples/3-mutation/src/Dog.re
@@ -55,6 +55,10 @@ let make =
       ~bellyscratches: int,
       ~description: string,
     ) => {
+  /* useMutation with variables applied at render time. */
+  let (_, executeLikeMutation) =
+    useMutation(~request=Mutations.LikeDog.make(~key=id, ()));
+
   let payload =
     React.useMemo1(
       () => {
@@ -65,10 +69,8 @@ let make =
       [|id|],
     );
 
-  let (_, executeLikeMutation) =
-    useMutation(~request=Mutations.LikeDog.make(~key=id, ()));
-
-  module TreatDogMutation = UrqlUseMutation.Make(Mutations.TreatDog);
+  /* useMutation functor API, allowing variables to be applied at execution time. */
+  module TreatDogMutation = MakeMutation(Mutations.TreatDog);
   let (_, executeTreatMutation) = TreatDogMutation.useMutation();
 
   <div className=DogStyles.container>
@@ -95,7 +97,7 @@ let make =
         emoji={j|🍖|j}
         count={string_of_int(treats)}
         hex="7b16ff"
-        onClick={_ => executeTreatMutation(payload) |> ignore}
+        onClick={_ => executeTreatMutation(Some(payload)) |> ignore}
       />
       <Mutation request={Mutations.BellyscratchDog.make(~key=id, ())}>
         ...{({executeMutation}) =>

--- a/src/hooks/UrqlUseMutation.rei
+++ b/src/hooks/UrqlUseMutation.rei
@@ -4,3 +4,22 @@ let useMutation:
     UrqlTypes.hookResponse('response),
     unit => Js.Promise.t(UrqlClient.ClientTypes.operationResult),
   );
+
+module type MutationConfig = {
+  type t;
+  let parse: Js.Json.t => t;
+  let query: string;
+};
+
+module type MakeType =
+  (Mutation: MutationConfig) =>
+   {
+    let useMutation:
+      unit =>
+      (
+        UrqlTypes.hookResponse(Mutation.t),
+        Js.Json.t => Js.Promise.t(UrqlClient.ClientTypes.operationResult),
+      );
+  };
+
+module Make: MakeType;

--- a/src/hooks/UrqlUseMutation.rei
+++ b/src/hooks/UrqlUseMutation.rei
@@ -7,19 +7,20 @@ let useMutation:
 
 module type MutationConfig = {
   type t;
-  let parse: Js.Json.t => t;
   let query: string;
+  let parse: Js.Json.t => t;
 };
 
-module type MakeType =
+module type MakeMutationType =
   (Mutation: MutationConfig) =>
    {
     let useMutation:
       unit =>
       (
         UrqlTypes.hookResponse(Mutation.t),
-        Js.Json.t => Js.Promise.t(UrqlClient.ClientTypes.operationResult),
+        option(Js.Json.t) =>
+        Js.Promise.t(UrqlClient.ClientTypes.operationResult),
       );
   };
 
-module Make: MakeType;
+module MakeMutation: MakeMutationType;

--- a/src/hooks/UrqlUseQuery.rei
+++ b/src/hooks/UrqlUseQuery.rei
@@ -14,3 +14,30 @@ let useQuery:
     unit
   ) =>
   useQueryResponse('response);
+
+module type QueryConfig = {
+  type t;
+  let query: string;
+  let parse: Js.Json.t => t;
+};
+
+module type MakeQueryType =
+  (Query: QueryConfig) =>
+   {
+    let useQuery:
+      (
+        ~variables: Js.Json.t=?,
+        ~requestPolicy: UrqlTypes.requestPolicy=?,
+        ~pause: bool=?,
+        unit
+      ) =>
+      (
+        UrqlTypes.hookResponse(Query.t),
+        React.callback(
+          option(UrqlClient.ClientTypes.partialOperationContext),
+          unit,
+        ),
+      );
+  };
+
+module MakeQuery: MakeQueryType;

--- a/src/hooks/UrqlUseSubscription.rei
+++ b/src/hooks/UrqlUseSubscription.rei
@@ -8,3 +8,21 @@ let useSubscription:
     ~handler: handler('acc, 'resp, 'ret)
   ) =>
   UrqlTypes.hookResponse('ret);
+
+module type SubscriptionConfig = {
+  type t;
+  let query: string;
+  let parse: Js.Json.t => t;
+};
+
+module type MakeSubscriptionType = {
+  type resp;
+
+  let useSubscription:
+    (~variables: Js.Json.t=?, ~handler: handler('acc, resp, 'ret)) =>
+    UrqlTypes.hookResponse('ret);
+};
+
+module MakeSubscription:
+  (Subscription: SubscriptionConfig) =>
+   MakeSubscriptionType with type resp = Subscription.t;


### PR DESCRIPTION
This PR adds a functor API for `reason-urql`'s hooks. The goal of the functor API is to address concerns raised in #128 concerning dynamic variables for mutations, where we want to pass variables at execution time rather than when the hook is ran. This is closer to how `urql` actually works – the `executeMutation` function returned by the `useMutation` hook accepts an optional `variables` argument that will be applied when the function is called.

The functor API would look to consumers like the following:

```reason
module LikeDog = [%graphql {|
    mutation likeDog($id: ID!) {
       likeDog(id: $id) {
           id
           name
           likes
       }
    }
|}];

[@react.component]
let make = (~id: string) => {
   module LikeDogMutation = ReasonUrql.Hooks.MakeMutation(LikeDog);
   let (result, executeMutation) = LikeDogMutation.useMutation();

   let payload = Js.Dict.empty();
   Js.Dict.set(payload, "id", Js.Json.string(id));

  <button onClick={_ev => executeMutation(Some(Js.Json.object_(payload))) |> ignore}>
     "Execute Mutation"->React.string
  </button>
};
```

In addition to adding a functor API for `useMutation`, I also added them for `useQuery` and `useSubscription`. This is more to offer folks the option of using the functor APIs if they like them, since folks coming from `reason-apollo` or `reason-apollo-hooks` will likely be most used to that approach.

Ideally, I'd love for us to find a way of achieving the above without the use of functors to keep the API simpler, but at this moment I think the functor API gets us closest to how `urql` actually works without sacrificing type inference. I'm very curious to see what people think here.

**Note:** Don't be alarmed by the "breaking build" in these commits. GitHub changed its billing structure and Formidable's plan doesn't give us access to GitHub Actions. So we're going to be switching back to Travis here soon.

cc/ @robinweser tagging you as well to take a peek!