### PR TITLE
add unit to `examples/5-subscription/src/app/Circles.re`

### DIFF
--- a/examples/5-subscription/src/app/Circles.re
+++ b/examples/5-subscription/src/app/Circles.re
@@ -36,6 +36,7 @@ let make = () => {
     useSubscription(
       ~request=SubscribeRandomInt.make(),
       ~handler=Handler(handler),
+      ()
     );
 
   switch (response) {


### PR DESCRIPTION
Subscription example needs `unit` call to handle newly add `Client.ClientTypes.partialOperationContext`