### PR TITLE
Attempt to fix Travis build not building tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 notifications:
   email: false
 
+branches:
+  only:
+    - master
+    - develop
+    - /^v\d+\.\d+\.\d+/
+
 language: node_js
-cache:
-  yarn: true
+
 node_js:
   - "10"
 


### PR DESCRIPTION
This PR is here purely to see if it'll help us fix the Travis build. For some peculiar reason, Travis has decided to stop building the project before attempting to run `yarn test`. This results in build errors complaining about no tests being found 🤔 Of course, our tests need to be built to be found, so if Travis fails to run `yarn build` beforehand we'll always see this error.