### PR TITLE
Remove useMemo from useSubscription

### DIFF
--- a/src/hooks/UrqlUseSubscription.re
+++ b/src/hooks/UrqlUseSubscription.re
@@ -81,23 +81,18 @@ let useSubscription =
       (),
     );
 
-  React.useMemo3(
-    () => {
-      let response: UrqlTypes.hookResponse(ret, 'extensions) =
-        switch (handler) {
-        | Handler(handlerFn) =>
-          useSubscriptionJs(
-            args,
-            Some((acc, data) => handlerFn(acc, parse(data))),
-          )[0]
-          |> useSubscriptionResponseToRecord(x => x)
-        | NoHandler =>
-          useSubscriptionJs(args, None)[0]
-          |> useSubscriptionResponseToRecord(parse)
-        };
+  let response: UrqlTypes.hookResponse(ret, 'extensions) =
+    switch (handler) {
+    | Handler(handlerFn) =>
+      useSubscriptionJs(
+        args,
+        Some((acc, data) => handlerFn(acc, parse(data))),
+      )[0]
+      |> useSubscriptionResponseToRecord(x => x)
+    | NoHandler =>
+      useSubscriptionJs(args, None)[0]
+      |> useSubscriptionResponseToRecord(parse)
+    };
 
-      response;
-    },
-    (handler, args, parse),
-  );
+  response;
 };

--- a/src/hooks/UrqlUseSubscription.re
+++ b/src/hooks/UrqlUseSubscription.re
@@ -29,7 +29,7 @@ external useSubscriptionJs:
  * A function for converting the response to useQuery from the JavaScript
  * representation to a typed Reason record.
  */
-let jsSubscriptionResponseToRecord =
+let urqlResponseToReason =
     (result): UrqlTypes.hookResponse('response, 'extensions) => {
   let data = result->UrqlTypes.jsDataGet->Js.Nullable.toOption;
   let error =
@@ -90,8 +90,5 @@ let useSubscription =
 
   let (jsResponse, _) = useSubscriptionJs(args, Some(handler'));
 
-  UrqlGuaranteedMemo.useGuaranteedMemo1(
-    jsSubscriptionResponseToRecord,
-    jsResponse,
-  );
+  UrqlGuaranteedMemo.useGuaranteedMemo1(urqlResponseToReason, jsResponse);
 };

--- a/src/hooks/UrqlUseSubscription.rei
+++ b/src/hooks/UrqlUseSubscription.rei
@@ -1,6 +1,6 @@
 type handler('acc, 'resp, 'ret) =
   | Handler((option('acc), 'resp) => 'acc): handler('acc, 'resp, 'acc)
-  | NoHandler: handler(_, 'resp, 'resp);
+  | NoHandler: handler('resp, 'resp, 'resp);
 
 let useSubscription:
   (

--- a/src/utils/UrqlGuaranteedMemo.re
+++ b/src/utils/UrqlGuaranteedMemo.re
@@ -1,4 +1,4 @@
-// React.useMemo has to semantic guarantee so we define our own
+// React.useMemo has no semantic guarantee so we define our own
 let useGuaranteedMemo1 = (computeValue, arg) => {
   let (memoizedState, setMemoizedState) =
     React.useState(() => computeValue(arg));

--- a/src/utils/UrqlGuaranteedMemo.re
+++ b/src/utils/UrqlGuaranteedMemo.re
@@ -1,0 +1,15 @@
+// React.useMemo has to semantic guarantee so we define our own
+let useGuaranteedMemo1 = (computeValue, arg) => {
+  let (memoizedState, setMemoizedState) =
+    React.useState(() => computeValue(arg));
+
+  React.useEffect1(
+    () => {
+      setMemoizedState(_ => computeValue(arg));
+      None;
+    },
+    [|arg|],
+  );
+
+  memoizedState;
+};


### PR DESCRIPTION
This is more of an issue than a PR. `useSubscription` is currently wrapping the JS hook with `useMemo` which errors with "can't call a hook from within a hook". It wasn't immediately apparent to me why `useMemo` was being used in quite this way. I would have expected the JS component to be doing proper checks on the args provided to it and `useSubscriptionArgs` looks to me like it would create a new object on every render anyway defeating `useMemo`? Anyway, I didn't dig too deep and just removed `useMemo` here. I'm sure there was a reason I'm not seeing—maybe it's worth a comment once it gets figured out.

Thanks!