### PR TITLE
Migrate to urql v1.7.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ type t =
 - Component bindings for `Query`, `Mutation`, `Subscription`, and `SubscriptionWithHandler` were removed. Just use the hooks APIs!
 - `Client` methods for `executeRequestOperation`, `reexecuteOperation`, `createRequestOperation`, and `dispatchOperation` were removed. These are no longer in `urql`'s public facing API.
 
+### Diff
+
+https://github.com/FormidableLabs/reason-urql/compare/v1.7.0...v2.0.0
+
 ## [1.7.0] - 2020-04-16
 
 This release migrates our dependency on `urql` to v1.5.1. It also migrates our `devDependency` on `bs-platform` (the BuckleScript compiler), to v7.2.2. While we don't expect this to affect end users still on BuckleScript v6, there may be small bugfixes and optimizations coming in the near future to support this migration.

--- a/examples/2-query/yarn.lock
+++ b/examples/2-query/yarn.lock
@@ -3392,11 +3392,8 @@ reason-react@^0.7.0:
     react-dom ">=16.8.1"
 
 "reason-urql@link:../..":
-  version "1.7.0"
-  dependencies:
-    bs-fetch "^0.5.2"
-    graphql "^14.1.1"
-    urql "1.6.3"
+  version "0.0.0"
+  uid ""
 
 regenerator-runtime@^0.13.2:
   version "0.13.2"
@@ -4144,10 +4141,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urql@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-1.6.3.tgz#0484a90a01d6fc8d0a6fb96bb4b2b2146a612c0d"
-  integrity sha512-KX8qHTGo8deSg41rrQEk9JhJTz6w/LBCdWhYutYjbCUrkoAF4lEiCkgOEiO0fEf+hpDg0nQTTkHTpRbgQ0yh1g==
+urql@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-1.7.0.tgz#3b5d53451e9b45163288618f2bad6fe0afc02e0e"
+  integrity sha512-mw9gZhq3u33FzT6nLIQGzTF/cVkl3+pM1Jr2mya9pyTQfRBMugurGpZTyIFZKZQK1zjSnO8LbI2gzelydctq3A==
   dependencies:
     react-wonka "^1.0.3"
     wonka "^3.2.1"

--- a/examples/3-mutation/src/Dog.re
+++ b/examples/3-mutation/src/Dog.re
@@ -52,47 +52,57 @@ let make =
       ~bellyscratches: int,
       ~description: string,
     ) => {
-  let (_, executeLikeMutation) =
+  let (likeState, executeLikeMutation) =
     Hooks.useMutation(~request=LikeDog.make(~key=id, ()));
 
   // Example of using hooks without graphql_ppx_re (or graphql_ppx).
-  let (_, executeTreatMutation) =
+  let (treatState, executeTreatMutation) =
     Hooks.useMutation(~request=TreatDog.make(~key=id, ()));
 
   /* Example of using hooks where the variables are only known when the
      mutation runs. */
-  let (_, executePatMutation) = Hooks.useDynamicMutation(PatDog.definition);
-  let (_, executeBellyscratchMutation) =
+  let (patState, executePatMutation) =
+    Hooks.useDynamicMutation(PatDog.definition);
+  let (bellyscratchState, executeBellyscratchMutation) =
     Hooks.useDynamicMutation(BellyscratchDog.definition);
 
   <div className=DogStyles.container>
     <img src=imageUrl alt=name className=DogStyles.image />
     <h3 className=DogStyles.title> {j|$name|j}->React.string </h3>
     <div className=DogStyles.buttons>
-      <EmojiButton
-        emoji={j|👍|j}
-        count={string_of_int(likes)}
-        hex="48a9dc"
-        onClick={_ => executeLikeMutation() |> ignore}
-      />
-      <EmojiButton
-        emoji={j|✋|j}
-        count={string_of_int(pats)}
-        hex="db4d3f"
-        onClick={_ => executePatMutation(~key=id, ()) |> ignore}
-      />
-      <EmojiButton
-        emoji={j|🍖|j}
-        count={string_of_int(treats)}
-        hex="7b16ff"
-        onClick={_ => executeTreatMutation() |> ignore}
-      />
-      <EmojiButton
-        emoji={j|🐾|j}
-        count={string_of_int(bellyscratches)}
-        hex="1bda2a"
-        onClick={_ => executeBellyscratchMutation(~key=id, ()) |> ignore}
-      />
+      {likeState.fetching
+       || treatState.fetching
+       || patState.fetching
+       || bellyscratchState.fetching
+         ? <Loading />
+         : <>
+             <EmojiButton
+               emoji={j|👍|j}
+               count={string_of_int(likes)}
+               hex="48a9dc"
+               onClick={_ => executeLikeMutation() |> ignore}
+             />
+             <EmojiButton
+               emoji={j|✋|j}
+               count={string_of_int(pats)}
+               hex="db4d3f"
+               onClick={_ => executePatMutation(~key=id, ()) |> ignore}
+             />
+             <EmojiButton
+               emoji={j|🍖|j}
+               count={string_of_int(treats)}
+               hex="7b16ff"
+               onClick={_ => executeTreatMutation() |> ignore}
+             />
+             <EmojiButton
+               emoji={j|🐾|j}
+               count={string_of_int(bellyscratches)}
+               hex="1bda2a"
+               onClick={_ =>
+                 executeBellyscratchMutation(~key=id, ()) |> ignore
+               }
+             />
+           </>}
     </div>
     <div> description->React.string </div>
   </div>;

--- a/examples/3-mutation/src/DogStyles.re
+++ b/examples/3-mutation/src/DogStyles.re
@@ -22,4 +22,5 @@ let image =
 
 let title = style([fontSize(rem(1.)), margin(px(0))]);
 
-let buttons = style([display(flexBox), alignItems(center)]);
+let buttons =
+  style([display(flexBox), alignItems(center), position(relative)]);

--- a/examples/3-mutation/src/EmojiButton.re
+++ b/examples/3-mutation/src/EmojiButton.re
@@ -5,9 +5,8 @@ let make =
       ~count: string,
       ~hex: string,
       ~onClick: ReactEvent.Mouse.t => unit,
-    ) => {
+    ) =>
   <button className={hex |> EmojiButtonStyles.emojiButton} onClick>
     <span className=EmojiButtonStyles.text> count->React.string </span>
     <span className=EmojiButtonStyles.text> emoji->React.string </span>
   </button>;
-};

--- a/examples/3-mutation/src/Loading.re
+++ b/examples/3-mutation/src/Loading.re
@@ -1,0 +1,4 @@
+[@react.component]
+let make = () => {
+  <div className=LoadingStyles.loading />;
+};

--- a/examples/3-mutation/src/LoadingStyles.re
+++ b/examples/3-mutation/src/LoadingStyles.re
@@ -1,0 +1,27 @@
+open Css;
+
+let spin = keyframes([(100, [transform(rotate(deg(360.)))])]);
+
+let loading =
+  style([
+    height(px(45)),
+    before([
+      unsafe("content", ""),
+      position(absolute),
+      top(pct(50.)),
+      left(pct(50.)),
+      width(px(20)),
+      height(px(20)),
+      marginTop(px(-10)),
+      marginLeft(px(-10)),
+      borderRadius(pct(50.)),
+      border(px(1), solid, hex("f6f")),
+      borderTopColor(hex("0e0")),
+      borderRightColor(hex("0dd")),
+      borderBottomColor(hex("f90")),
+      animationName(spin),
+      animationDuration(600),
+      animationTimingFunction(linear),
+      animationIterationCount(infinite),
+    ]),
+  ]);

--- a/examples/3-mutation/yarn.lock
+++ b/examples/3-mutation/yarn.lock
@@ -3392,11 +3392,8 @@ reason-react@^0.7.0:
     react-dom ">=16.8.1"
 
 "reason-urql@link:../..":
-  version "1.7.0"
-  dependencies:
-    bs-fetch "^0.5.2"
-    graphql "^14.1.1"
-    urql "1.6.3"
+  version "0.0.0"
+  uid ""
 
 regenerator-runtime@^0.13.2:
   version "0.13.2"
@@ -4144,10 +4141,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urql@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-1.6.3.tgz#0484a90a01d6fc8d0a6fb96bb4b2b2146a612c0d"
-  integrity sha512-KX8qHTGo8deSg41rrQEk9JhJTz6w/LBCdWhYutYjbCUrkoAF4lEiCkgOEiO0fEf+hpDg0nQTTkHTpRbgQ0yh1g==
+urql@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-1.7.0.tgz#3b5d53451e9b45163288618f2bad6fe0afc02e0e"
+  integrity sha512-mw9gZhq3u33FzT6nLIQGzTF/cVkl3+pM1Jr2mya9pyTQfRBMugurGpZTyIFZKZQK1zjSnO8LbI2gzelydctq3A==
   dependencies:
     react-wonka "^1.0.3"
     wonka "^3.2.1"

--- a/examples/4-exchanges/yarn.lock
+++ b/examples/4-exchanges/yarn.lock
@@ -3392,11 +3392,8 @@ reason-react@^0.7.0:
     react-dom ">=16.8.1"
 
 "reason-urql@link:../..":
-  version "1.7.0"
-  dependencies:
-    bs-fetch "^0.5.2"
-    graphql "^14.1.1"
-    urql "1.6.3"
+  version "0.0.0"
+  uid ""
 
 regenerator-runtime@^0.13.2:
   version "0.13.2"
@@ -4144,10 +4141,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urql@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-1.6.3.tgz#0484a90a01d6fc8d0a6fb96bb4b2b2146a612c0d"
-  integrity sha512-KX8qHTGo8deSg41rrQEk9JhJTz6w/LBCdWhYutYjbCUrkoAF4lEiCkgOEiO0fEf+hpDg0nQTTkHTpRbgQ0yh1g==
+urql@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-1.7.0.tgz#3b5d53451e9b45163288618f2bad6fe0afc02e0e"
+  integrity sha512-mw9gZhq3u33FzT6nLIQGzTF/cVkl3+pM1Jr2mya9pyTQfRBMugurGpZTyIFZKZQK1zjSnO8LbI2gzelydctq3A==
   dependencies:
     react-wonka "^1.0.3"
     wonka "^3.2.1"

--- a/examples/5-subscription/yarn.lock
+++ b/examples/5-subscription/yarn.lock
@@ -4193,11 +4193,8 @@ reason-react@^0.7.0:
     react-dom ">=16.8.1"
 
 "reason-urql@link:../..":
-  version "1.7.0"
-  dependencies:
-    bs-fetch "^0.5.2"
-    graphql "^14.1.1"
-    urql "1.6.3"
+  version "0.0.0"
+  uid ""
 
 regenerator-runtime@^0.13.2:
   version "0.13.2"
@@ -5072,10 +5069,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urql@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-1.6.3.tgz#0484a90a01d6fc8d0a6fb96bb4b2b2146a612c0d"
-  integrity sha512-KX8qHTGo8deSg41rrQEk9JhJTz6w/LBCdWhYutYjbCUrkoAF4lEiCkgOEiO0fEf+hpDg0nQTTkHTpRbgQ0yh1g==
+urql@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-1.7.0.tgz#3b5d53451e9b45163288618f2bad6fe0afc02e0e"
+  integrity sha512-mw9gZhq3u33FzT6nLIQGzTF/cVkl3+pM1Jr2mya9pyTQfRBMugurGpZTyIFZKZQK1zjSnO8LbI2gzelydctq3A==
   dependencies:
     react-wonka "^1.0.3"
     wonka "^3.2.1"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "bs-fetch": "^0.5.2",
     "graphql": "^14.1.1",
-    "urql": "1.6.3"
+    "urql": "1.7.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.9.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4419,10 +4419,10 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-urql@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-1.6.3.tgz#0484a90a01d6fc8d0a6fb96bb4b2b2146a612c0d"
-  integrity sha512-KX8qHTGo8deSg41rrQEk9JhJTz6w/LBCdWhYutYjbCUrkoAF4lEiCkgOEiO0fEf+hpDg0nQTTkHTpRbgQ0yh1g==
+urql@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-1.7.0.tgz#3b5d53451e9b45163288618f2bad6fe0afc02e0e"
+  integrity sha512-mw9gZhq3u33FzT6nLIQGzTF/cVkl3+pM1Jr2mya9pyTQfRBMugurGpZTyIFZKZQK1zjSnO8LbI2gzelydctq3A==
   dependencies:
     react-wonka "^1.0.3"
     wonka "^3.2.1"


### PR DESCRIPTION
This PR brings us up to `urql` v1.7.0! Most of the code included this PR are small updates to our examples, but no major changes to the bindings. Based on [the CHANGELOG for `urql` v1.7.0](https://github.com/FormidableLabs/urql/blob/v1.7.0/CHANGELOG.md#v170), it seemed like the major change of that version was the splitting of `urql` into separate entry points.

I'm not fully sure how we want to handle that here. From my perspective, the majority use case for using `reason-urql` is in conjunction with ReasonReact, so I'm not yet sold on splitting the bindings into a separate entry point as well (though I would love other opinions and discussion on this). If we did decide to support the separate entry point, I think it'd mostly involve:

- Modifying our `[@bs.module]` bindings for certain parts of the API to point at `@urql/core` rather than `urql`.
- Potentially mirroring the setup of `urql` with yarn workspaces and `@reason-urql/core` and `reason-urql` as two separate workspaces.

I'm not sure what we think, so let's chat!