### PR TITLE
add more options to query and mutation

### DIFF
--- a/src/Client.re
+++ b/src/Client.re
@@ -352,21 +352,29 @@ let query =
     (
       ~client,
       ~request,
+      ~additionalTypenames=?,
       ~fetchOptions=?,
+      ~fetch=?,
       ~requestPolicy=?,
       ~url=?,
       ~pollInterval=?,
       ~meta=?,
+      ~suspense=?,
+      ~preferGetMethod=?,
       (),
     ) => {
   executeQuery(
     ~client,
     ~request,
+    ~additionalTypenames?,
     ~fetchOptions?,
+    ~fetch?,
     ~requestPolicy?,
     ~url?,
     ~pollInterval?,
     ~meta?,
+    ~suspense?,
+    ~preferGetMethod?,
     (),
   )
   |> Wonka.take(1)
@@ -377,21 +385,29 @@ let mutation =
     (
       ~client,
       ~request,
+      ~additionalTypenames=?,
       ~fetchOptions=?,
+      ~fetch=?,
       ~requestPolicy=?,
       ~url=?,
       ~pollInterval=?,
       ~meta=?,
+      ~suspense=?,
+      ~preferGetMethod=?,
       (),
     ) => {
   executeMutation(
     ~client,
     ~request,
+    ~additionalTypenames?,
     ~fetchOptions?,
+    ~fetch?,
     ~requestPolicy?,
     ~url?,
     ~pollInterval?,
     ~meta?,
+    ~suspense?,
+    ~preferGetMethod?,
     (),
   )
   |> Wonka.take(1)

--- a/src/Client.rei
+++ b/src/Client.rei
@@ -188,11 +188,15 @@ let query:
   (
     ~client: t,
     ~request: Types.request('response),
+    ~additionalTypenames: array(string)=?,
     ~fetchOptions: Fetch.requestInit=?,
+    ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
     ~requestPolicy: Types.requestPolicy=?,
     ~url: string=?,
     ~pollInterval: int=?,
     ~meta: Types.operationDebugMeta=?,
+    ~suspense: bool=?,
+    ~preferGetMethod: bool=?,
     unit
   ) =>
   Js.Promise.t(clientResponse('response));
@@ -201,11 +205,15 @@ let mutation:
   (
     ~client: t,
     ~request: Types.request('response),
+    ~additionalTypenames: array(string)=?,
     ~fetchOptions: Fetch.requestInit=?,
+    ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
     ~requestPolicy: Types.requestPolicy=?,
     ~url: string=?,
     ~pollInterval: int=?,
     ~meta: Types.operationDebugMeta=?,
+    ~suspense: bool=?,
+    ~preferGetMethod: bool=?,
     unit
   ) =>
   Js.Promise.t(clientResponse('response));


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/FormidableLabs/reason-urql/pull/161#discussion_r476590067), this add extra options to the `query` and `mutation` functions to match the `executeQuery` and `executeMutation` signatures. 

