### PR TITLE
Fix errors in docs missed in v2 release.

### DIFF
--- a/docs/client-and-provider.md
+++ b/docs/client-and-provider.md
@@ -6,7 +6,7 @@ The client is the central orchestrator of `reason-urql`, and is responsible for 
 
 The `Provider`'s responsibility is to pass the `reason-urql` client instance down to `useQuery`, `useMutation`, `useDynamicMutation`, and `useSubcription` hooks through context. Wrap the root of your application with `Provider`.
 
-You can access the `Provider` component by referencing `Client.Provider` after `open`ing `ReasonUrql`.
+You can access the `Provider` component by referencing `Context.Provider` after `open`ing `ReasonUrql`.
 
 ### Props
 
@@ -81,16 +81,18 @@ let client = Client.make(~url="https://localhost:3000/graphql", ~fetchOptions, (
 ```reason
 open ReasonUrql;
 
-let client = Client.(make(
-  ~url="https://localhost:3000/graphql",
-  ~exchanges=[|
-    Exchanges.debugExchange,
-    Exchanges.dedupExchange,
-    Exchanges.cacheExchange,
-    Exchanges.fetchExchange
-  |],
-  ()
-));
+let client = Client.(
+  make(
+    ~url="https://localhost:3000/graphql",
+    ~exchanges=[|
+      Exchanges.debugExchange,
+      Exchanges.dedupExchange,
+      Exchanges.cacheExchange,
+      Exchanges.fetchExchange
+    |],
+    ()
+  )
+);
 ```
 
 **Create a client with a non-default requestPolicy.**
@@ -192,7 +194,7 @@ module GetAllDogs = [%graphql
 ];
 
 Client.query(~client, ~request=GetAllDogs.make(), ())
-  |> Js.Promise.then_((data) => {
+  |> Js.Promise.then_(data => {
     switch(Client.(data.response)) {
       | Data(d) => /* Access data returned from executing the request. */
       | Error(e) => /* Access any errors returned from executing the request. */
@@ -290,7 +292,7 @@ module LikeDog = [%graphql
 ];
 
 Client.mutation(~client, ~request=LikeDog.make(~key="VmeRTX7j-", ()), ())
-  |> Js.Promise.then_((data) => {
+  |> Js.Promise.then_(data => {
     switch(Client.(data.response)) {
       | Data(d) => /* Access data returned from executing the request. */
       | Error(e) => /* Access any errors returned from executing the request. */

--- a/docs/client-and-provider.md
+++ b/docs/client-and-provider.md
@@ -6,6 +6,8 @@ The client is the central orchestrator of `reason-urql`, and is responsible for 
 
 The `Provider`'s responsibility is to pass the `reason-urql` client instance down to `useQuery`, `useMutation`, `useDynamicMutation`, and `useSubcription` hooks through context. Wrap the root of your application with `Provider`.
 
+You can access the `Provider` component by referencing `Client.Provider` after `open`ing `ReasonUrql`.
+
 ### Props
 
 | Prop    | Type       | Description                 |
@@ -19,7 +21,7 @@ open ReasonUrql;
 
 let client = Client.make(~url="https://localhost:3000/graphql", ());
 
-ReactDOMRe.renderToElementWithId(<Provider value=client><App /></Provider>, "root");
+ReactDOMRe.renderToElementWithId(<Context.Provider value=client><App /></Context.Provider>, "root");
 ```
 
 ## Client
@@ -79,16 +81,16 @@ let client = Client.make(~url="https://localhost:3000/graphql", ~fetchOptions, (
 ```reason
 open ReasonUrql;
 
-let client = Client.make(
+let client = Client.(make(
   ~url="https://localhost:3000/graphql",
   ~exchanges=[|
-    Client.Exchanges.debugExchange,
-    Client.Exchanges.dedupExchange,
-    Client.Exchanges.cacheExchange,
-    Client.Exchanges.fetchExchange
+    Exchanges.debugExchange,
+    Exchanges.dedupExchange,
+    Exchanges.cacheExchange,
+    Exchanges.fetchExchange
   |],
   ()
-);
+));
 ```
 
 **Create a client with a non-default requestPolicy.**
@@ -190,7 +192,7 @@ module GetAllDogs = [%graphql
 ];
 
 Client.query(~client, ~request=GetAllDogs.make(), ())
-  |> Js.Promise.then_((. data) => {
+  |> Js.Promise.then_((data) => {
     switch(Client.(data.response)) {
       | Data(d) => /* Access data returned from executing the request. */
       | Error(e) => /* Access any errors returned from executing the request. */
@@ -288,7 +290,7 @@ module LikeDog = [%graphql
 ];
 
 Client.mutation(~client, ~request=LikeDog.make(~key="VmeRTX7j-", ()), ())
-  |> Js.Promise.then_((. data) => {
+  |> Js.Promise.then_((data) => {
     switch(Client.(data.response)) {
       | Data(d) => /* Access data returned from executing the request. */
       | Error(e) => /* Access any errors returned from executing the request. */

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -1,6 +1,8 @@
 # Exchanges
 
-Exchanges are the mechanism by which `reason-urql` modifies requests before they are sent to your GraphQL API and alters responses as they are received. If you want to add some additional functionality to your GraphQL operations, this is a great place to do that. The following exchanges are provided out of the box with `reason-urql`.
+Exchanges are the mechanism by which `reason-urql` modifies requests before they are sent to your GraphQL API and alters responses as they are received. If you want to add some additional functionality to your GraphQL operations, this is a great place to do that.
+
+The `Exchanges` `module` is a submodule of the `Client` module and can be referenced at `ReasonUrql.Client.Exchanges`. The following exchanges are provided out of the box with `reason-urql`.
 
 #### `cacheExchange`
 
@@ -21,15 +23,17 @@ The above three exchanges make up `urql`'s `defaultExchanges`. When you create a
 ```reason
 open ReasonUrql;
 
-let client = Client.make(
-  ~url="https://mygraphql.com/api",
-  ~exchanges=[|
-    myCustomExchange,
-    Exchanges.dedupExchange,
-    Exchanges.cacheExchange,
-    Exchanges.fetchExchange
-  |],
-  ()
+let client = Client.(
+  make(
+    ~url="https://mygraphql.com/api",
+    ~exchanges=[|
+      myCustomExchange,
+      Exchanges.dedupExchange,
+      Exchanges.cacheExchange,
+      Exchanges.fetchExchange
+    |],
+    ()
+  )
 );
 ```
 
@@ -59,17 +63,19 @@ let forwardSubscription = operation => subscriptionClient##request(operation);
 
 /* Confirgure options for reason-urql's subscriptionExchange. */
 let subscriptionExchangeOpts =
-  Exchanges.{forwardSubscription: forwardSubscription};
+  Client.Exchanges.{forwardSubscription: forwardSubscription};
 
 /* Create the subcription exchange. */
 let subscriptionExchange =
-  Exchanges.subscriptionExchange(subscriptionExchangeOpts);
+  Client.Exchanges.subscriptionExchange(subscriptionExchangeOpts);
 
 /* Include the subscriptionExchange in your client's exchanges array. */
-let client = Client.make(
-  ~url="https://localhost:3000/graphql",
-  ~exchanges=Array.append(Exchanges.defaultExchanges, [|subscriptionExchange|]),
-  ()
+let client = Client.(
+  make(
+    ~url="https://localhost:3000/graphql",
+    ~exchanges=Array.append(Exchanges.defaultExchanges, [|subscriptionExchange|]),
+    ()
+  )
 );
 ```
 
@@ -87,15 +93,17 @@ open ReasonUrql;
 
 let ssrCache = Exchanges.ssrExchange();
 
-let client = Client.make(
-  ~url="http://localhost:3000",
-  ~exchanges=[|
-    Exchanges.dedupExchange,
-    Exchanges.cacheExchange,
-    ssrCache,
-    Exchanges.fetchExchange
-  |],
-  ()
+let client = Client.(
+  make(
+    ~url="http://localhost:3000",
+    ~exchanges=[|
+      Exchanges.dedupExchange,
+      Exchanges.cacheExchange,
+      ssrCache,
+      Exchanges.fetchExchange
+    |],
+    ()
+  )
 );
 ```
 
@@ -104,19 +112,19 @@ The resulting data structure returned from creating the `ssrExchange` can be acc
 - `extractData` – this is typically used on the server-side to extract data returned from your GraphQL requests after they've been executed on the server.
 
 ```reason
-let ssrCache = Exchanges.ssrExchange(~ssrExchangeParams, ());
+let ssrCache = Client.Exchanges.ssrExchange(~ssrExchangeParams, ());
 
 /* Extract data from the ssrCache. (Server-side) */
-let extractedData = Exchanges.extractData(~exchange=ssrCache);
+let extractedData = Client.Exchanges.extractData(~exchange=ssrCache);
 ```
 
 - `restoreData` is typically used to rehydrate the client with data from the server. The `restore` argument is what allows you to reference the data returned from the server to the client.
 
 ```reason
-let ssrCache = Exchanges.ssrExchange(~ssrExchangeParams, ());
+let ssrCache = Client.Exchanges.ssrExchange(~ssrExchangeParams, ());
 
 /* Extract data from the ssrCache. */
-let extractedData = Exchanges.restoreData(~exchange=ssrCache, ~restore=urqlData);
+let extractedData = Client.Exchanges.restoreData(~exchange=ssrCache, ~restore=urqlData);
 ```
 
 This part of the API is still quite experimental, as server-side rendering in Reason with Next.js is still in its infancy. Use with caution. For more information, read `urql`'s server-side rendering guide [here](https://github.com/FormidableLabs/urql/blob/master/docs/basics.md#server-side-rendering). To see an example of server-side rendering with `reason-urql`, check out our [`reason-urql-ssr` example](https://github.com/parkerziegler/reason-urql-ssr).
@@ -155,7 +163,7 @@ open ReasonUrql;
 /* This is the native debugExchange that ships with `urql`, re-implemented in Reason.
      Typically, you'd just add Exchanges.debugExchange to the Client's exchange array.
    */
-let debugExchange = (Exchanges.{forward}) =>
+let debugExchange = (Client.Exchanges.{forward}) =>
   /* Notice this function is uncurried using BuckleScript's uncurrying syntax.
   We want to ensure that our exchange returns a function that accepts operations. */
   (. ops) =>
@@ -180,7 +188,7 @@ open ReasonUrql;
 /* This is the native debugExchange that ships with `urql`, re-implemented in Reason.
      Typically, you'd just add Exchanges.debugExchange to the Client's exchange array.
    */
-let debugExchange = (Exchanges.{forward}) =>
+let debugExchange = (Client.Exchanges.{forward}) =>
   (. ops) =>
     ops
     |> Wonka.tap((. op) =>
@@ -192,14 +200,16 @@ let debugExchange = (Exchanges.{forward}) =>
        );
 
 let client =
-  Client.make(
-    ~url="https://my-graphql-endpoint.com/graphql",
-    ~exchanges=[|
-      debugExchange,
-      Exchanges.dedupExchange,
-      Exchanges.cacheExchange,
-      Exchanges.fetchExchange
-    |],
+  Client.(
+    make(
+      ~url="https://my-graphql-endpoint.com/graphql",
+      ~exchanges=[|
+        debugExchange,
+        Exchanges.dedupExchange,
+        Exchanges.cacheExchange,
+        Exchanges.fetchExchange
+      |],
     (),
+    )
   );
 ```

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -112,6 +112,8 @@ The resulting data structure returned from creating the `ssrExchange` can be acc
 - `extractData` – this is typically used on the server-side to extract data returned from your GraphQL requests after they've been executed on the server.
 
 ```reason
+open ReasonUrql;
+
 let ssrCache = Client.Exchanges.ssrExchange(~ssrExchangeParams, ());
 
 /* Extract data from the ssrCache. (Server-side) */
@@ -121,6 +123,8 @@ let extractedData = Client.Exchanges.extractData(~exchange=ssrCache);
 - `restoreData` is typically used to rehydrate the client with data from the server. The `restore` argument is what allows you to reference the data returned from the server to the client.
 
 ```reason
+open ReasonUrql;
+
 let ssrCache = Client.Exchanges.ssrExchange(~ssrExchangeParams, ());
 
 /* Extract data from the ssrCache. */
@@ -199,17 +203,16 @@ let debugExchange = (Client.Exchanges.{forward}) =>
          Js.log2("[debugExchange]: Completed operation: ", res)
        );
 
-let client =
-  Client.(
-    make(
-      ~url="https://my-graphql-endpoint.com/graphql",
-      ~exchanges=[|
-        debugExchange,
-        Exchanges.dedupExchange,
-        Exchanges.cacheExchange,
-        Exchanges.fetchExchange
-      |],
-    (),
-    )
-  );
+let client = Client.(
+  make(
+    ~url="https://my-graphql-endpoint.com/graphql",
+    ~exchanges=[|
+      debugExchange,
+      Exchanges.dedupExchange,
+      Exchanges.cacheExchange,
+      Exchanges.fetchExchange
+    |],
+  (),
+  )
+);
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ let client = Client.make(~url="https://mygraphqlapi.com/graphql", ());
 /* Wrap your application in Provider, passing it the client as a prop. */
 [@react.component]
 let make = () =>
-  <Provider value=client><App /></Provider>
+  <Context.Provider value=client><App /></Context.Provider>
 ```
 
 ## Using Your First Hook
@@ -116,7 +116,7 @@ let make = (~key: string) => {
   let request = LikeDogMutation.make(~key, ());
 
   /* Pass the request to useMutation. */
-  let (_, executeMutation) = Hooks.useMutation(~request, ());
+  let (_, executeMutation) = Hooks.useMutation(~request);
 
   <button onClick={_e => executeMutation() |> ignore}>
       "Execute the Mutation (and Reward a Good Dog)"->React.string
@@ -137,7 +137,7 @@ let make = (~key: string) => {
   let request = LikeDogMutation.make(~key, ());
 
   /* Pass the request to useMutation. */
-  let (Hooks.{ response }, executeMutation) = Hooks.useMutation(~request, ());
+  let (Hooks.{ response }, executeMutation) = Hooks.useMutation(~request);
 
   let button = React.useMemo1(() =>
     <button onClick={_e => executeMutation() |> ignore}>


### PR DESCRIPTION
Fix #204 

@MoOx pointed out some glaring inconsistencies in our docs and this PR fixes them!

- [X] Properly document referencing `Provider` from the `Context` module (i.e. as `Context.Provider`).
- [X] Remove erroneous `unit` parameter (`()`) from `useMutation` examples.
- [X] Document `Exchanges` as a submodule of `Client`. Include proper referencing syntax.
- [X] Fix `Js.Promise.t` syntax errors (erroneous uncurry operator).