### PR TITLE
Bind last APIs available in urql 1.10.

### DIFF
--- a/__tests__/Types_test.re
+++ b/__tests__/Types_test.re
@@ -2,18 +2,17 @@ open Jest;
 
 let it = test;
 
-let mockOperationContext =
-  Types.{
-    additionalTypenames: None,
-    fetch: None,
-    fetchOptions: None,
-    requestPolicy: `CacheFirst,
-    url: "https://localhost:3000/graphql",
-    pollInterval: None,
-    meta: None,
-    suspense: Some(false),
-    preferGetMethod: Some(false),
-  };
+let mockOperationContext: Types.operationContext = {
+  additionalTypenames: None,
+  fetch: None,
+  fetchOptions: None,
+  requestPolicy: `CacheFirst,
+  url: "https://localhost:3000/graphql",
+  pollInterval: None,
+  meta: None,
+  suspense: Some(false),
+  preferGetMethod: Some(false),
+};
 
 let mockOperation =
   Types.{

--- a/examples/1-execute-query-mutation/webpack.config.js
+++ b/examples/1-execute-query-mutation/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
     alias: {
       react: path.resolve("./node_modules/react"),
       "react-dom": path.resolve("./node_modules/react-dom"),
-      urql: path.resolve("./node_modules/urql"),
+      urql: path.resolve("../../node_modules/urql"),
     },
   },
 };

--- a/examples/2-query/src/index.re
+++ b/examples/2-query/src/index.re
@@ -1,7 +1,7 @@
 open ReasonUrql;
 
 /* Instatiate the client. */
-let client = Client.make(~url="https://graphql-pokemon.now.sh", ());
+let client = Client.make(~url="https://graphql-pokemon2.vercel.app", ());
 
 ReactDOMRe.renderToElementWithId(
   <Context.Provider value=client> <Container /> </Context.Provider>,

--- a/examples/2-query/webpack.config.js
+++ b/examples/2-query/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
     alias: {
       react: path.resolve("./node_modules/react"),
       "react-dom": path.resolve("./node_modules/react-dom"),
-      urql: path.resolve("./node_modules/urql"),
+      urql: path.resolve("../../node_modules/urql"),
     },
   },
 };

--- a/examples/3-mutation/webpack.config.js
+++ b/examples/3-mutation/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
     alias: {
       react: path.resolve("./node_modules/react"),
       "react-dom": path.resolve("./node_modules/react-dom"),
-      urql: path.resolve("./node_modules/urql"),
+      urql: path.resolve("../../node_modules/urql"),
     },
   },
 };

--- a/examples/4-exchanges/webpack.config.js
+++ b/examples/4-exchanges/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
     alias: {
       react: path.resolve("./node_modules/react"),
       "react-dom": path.resolve("./node_modules/react-dom"),
-      urql: path.resolve("./node_modules/urql"),
+      urql: path.resolve("../../node_modules/urql"),
     },
   },
 };

--- a/examples/5-subscription/src/app/index.re
+++ b/examples/5-subscription/src/app/index.re
@@ -9,19 +9,13 @@ let client =
 
 let forwardSubscription = operation => client##request(operation);
 
-let subscriptionExchangeOpts =
-  Client.Exchanges.{forwardSubscription: forwardSubscription};
-
-let subscriptionExchange =
-  Client.Exchanges.subscriptionExchange(subscriptionExchangeOpts);
-
 let urqlClient =
   Client.make(
     ~url="http://localhost:4000/graphql",
     ~exchanges=
       Array.append(
         Client.Exchanges.defaultExchanges,
-        [|subscriptionExchange|],
+        [|Client.Exchanges.subscriptionExchange(~forwardSubscription, ())|],
       ),
     (),
   );

--- a/examples/5-subscription/webpack.config.js
+++ b/examples/5-subscription/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
     alias: {
       react: path.resolve("./node_modules/react"),
       "react-dom": path.resolve("./node_modules/react-dom"),
-      urql: path.resolve("./node_modules/urql"),
+      urql: path.resolve("../../node_modules/urql"),
     },
   },
 };

--- a/src/Client.rei
+++ b/src/Client.rei
@@ -1,4 +1,10 @@
-type t;
+type t = {
+  url: string,
+  suspense: bool,
+  preferGetMethod: bool,
+  requestPolicy: string,
+  maskTypename: bool,
+};
 
 type fetchOptions('a) =
   | FetchOpts(Fetch.requestInit): fetchOptions(Fetch.requestInit)
@@ -71,13 +77,14 @@ module Exchanges: {
 
   type subscriptionForwarder =
     subscriptionOperation => observableLike(Types.executionResult);
-  type subscriptionExchangeOpts = {
-    forwardSubscription: subscriptionForwarder,
-  };
 
-  [@bs.module "urql"]
-  external subscriptionExchange: subscriptionExchangeOpts => t =
-    "subscriptionExchange";
+  let subscriptionExchange:
+    (
+      ~forwardSubscription: subscriptionForwarder,
+      ~enableAllOperations: bool=?,
+      unit
+    ) =>
+    t;
 
   /* Specific types for the ssrExchange. */
   type serializedError = {
@@ -201,23 +208,6 @@ let query:
   ) =>
   Js.Promise.t(clientResponse('response));
 
-let readQuery:
-  (
-    ~client: t,
-    ~request: Types.request('response),
-    ~additionalTypenames: array(string)=?,
-    ~fetchOptions: Fetch.requestInit=?,
-    ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
-    ~requestPolicy: Types.requestPolicy=?,
-    ~url: string=?,
-    ~pollInterval: int=?,
-    ~meta: Types.operationDebugMeta=?,
-    ~suspense: bool=?,
-    ~preferGetMethod: bool=?,
-    unit
-  ) =>
-  option(clientResponse('response));
-
 let mutation:
   (
     ~client: t,
@@ -234,3 +224,37 @@ let mutation:
     unit
   ) =>
   Js.Promise.t(clientResponse('response));
+
+let subscription:
+  (
+    ~client: t,
+    ~request: Types.request('response),
+    ~additionalTypenames: array(string)=?,
+    ~fetchOptions: Fetch.requestInit=?,
+    ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
+    ~requestPolicy: Types.requestPolicy=?,
+    ~url: string=?,
+    ~pollInterval: int=?,
+    ~meta: Types.operationDebugMeta=?,
+    ~suspense: bool=?,
+    ~preferGetMethod: bool=?,
+    unit
+  ) =>
+  Wonka.Types.sourceT(clientResponse('response));
+
+let readQuery:
+  (
+    ~client: t,
+    ~request: Types.request('response),
+    ~additionalTypenames: array(string)=?,
+    ~fetchOptions: Fetch.requestInit=?,
+    ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
+    ~requestPolicy: Types.requestPolicy=?,
+    ~url: string=?,
+    ~pollInterval: int=?,
+    ~meta: Types.operationDebugMeta=?,
+    ~suspense: bool=?,
+    ~preferGetMethod: bool=?,
+    unit
+  ) =>
+  option(clientResponse('response));

--- a/src/Types.re
+++ b/src/Types.re
@@ -46,26 +46,16 @@ type operationContext = {
   preferGetMethod: option(bool),
 };
 
-[@bs.deriving {abstract: light}]
 type partialOperationContext = {
-  [@bs.optional]
-  additionalTypenames: array(string),
-  [@bs.optional]
-  fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response),
-  [@bs.optional]
-  fetchOptions: Fetch.requestInit,
-  [@bs.optional]
-  requestPolicy: string,
-  [@bs.optional]
-  url: string,
-  [@bs.optional]
-  pollInterval: int,
-  [@bs.optional]
-  meta: operationDebugMeta,
-  [@bs.optional]
-  suspense: bool,
-  [@bs.optional]
-  preferGetMethod: bool,
+  additionalTypenames: option(array(string)),
+  fetch: option((string, Fetch.requestInit) => Js.Promise.t(Fetch.response)),
+  fetchOptions: option(Fetch.requestInit),
+  requestPolicy: option(string),
+  url: option(string),
+  pollInterval: option(int),
+  meta: option(operationDebugMeta),
+  suspense: option(bool),
+  preferGetMethod: option(bool),
 };
 
 /* The active GraphQL operation. */
@@ -119,7 +109,7 @@ type hookResponse('response, 'extensions) = {
   stale: bool,
 };
 
-type jsHookResponse('response, 'extensions) = {
+type hookResponseJs('response, 'extensions) = {
   operation,
   fetching: bool,
   data: option('response),

--- a/src/Types.rei
+++ b/src/Types.rei
@@ -36,26 +36,16 @@ type operationContext = {
   preferGetMethod: option(bool),
 };
 
-[@bs.deriving {abstract: light}]
 type partialOperationContext = {
-  [@bs.optional]
-  additionalTypenames: array(string),
-  [@bs.optional]
-  fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response),
-  [@bs.optional]
-  fetchOptions: Fetch.requestInit,
-  [@bs.optional]
-  requestPolicy: string,
-  [@bs.optional]
-  url: string,
-  [@bs.optional]
-  pollInterval: int,
-  [@bs.optional]
-  meta: operationDebugMeta,
-  [@bs.optional]
-  suspense: bool,
-  [@bs.optional]
-  preferGetMethod: bool,
+  additionalTypenames: option(array(string)),
+  fetch: option((string, Fetch.requestInit) => Js.Promise.t(Fetch.response)),
+  fetchOptions: option(Fetch.requestInit),
+  requestPolicy: option(string),
+  url: option(string),
+  pollInterval: option(int),
+  meta: option(operationDebugMeta),
+  suspense: option(bool),
+  preferGetMethod: option(bool),
 };
 
 /* The active GraphQL operation. */
@@ -109,7 +99,7 @@ type hookResponse('response, 'extensions) = {
   stale: bool,
 };
 
-type jsHookResponse('response, 'extensions) = {
+type hookResponseJs('response, 'extensions) = {
   operation,
   fetching: bool,
   data: option('response),
@@ -120,7 +110,7 @@ type jsHookResponse('response, 'extensions) = {
 
 let urqlResponseToReason:
   (
-    ~response: jsHookResponse(Js.Json.t, 'extensions),
+    ~response: hookResponseJs(Js.Json.t, 'extensions),
     ~parse: Js.Json.t => 'response
   ) =>
   hookResponse('response, 'extensions);

--- a/src/Utils.re
+++ b/src/Utils.re
@@ -1,0 +1,21 @@
+[@bs.module "urql"]
+external stringifyVariablies: 'a => string = "stringifyVariables";
+
+[@bs.module "urql"]
+external createRequest:
+  (~query: string, ~variables: Js.Json.t=?, unit) => Types.graphqlRequest =
+  "createRequest";
+
+[@bs.module "urql"]
+external makeResult:
+  (Types.operation, 'a, option('b)) => Types.operationResult =
+  "makeResult";
+
+[@bs.module "urql"]
+external makeErrorResult:
+  (Types.operation, Js.Exn.t, option('a)) => Types.operationResult =
+  "makeErrorResult";
+
+[@bs.module "urql"] external formatDocument: 'a => 'a = "formatDocument";
+
+[@bs.module "urql"] external maskTypename: 'a => 'a = "maskTypename";

--- a/src/Utils.rei
+++ b/src/Utils.rei
@@ -1,0 +1,21 @@
+[@bs.module "urql"]
+external stringifyVariablies: 'a => string = "stringifyVariables";
+
+[@bs.module "urql"]
+external createRequest:
+  (~query: string, ~variables: Js.Json.t=?, unit) => Types.graphqlRequest =
+  "createRequest";
+
+[@bs.module "urql"]
+external makeResult:
+  (Types.operation, 'a, option('b)) => Types.operationResult =
+  "makeResult";
+
+[@bs.module "urql"]
+external makeErrorResult:
+  (Types.operation, Js.Exn.t, option('a)) => Types.operationResult =
+  "makeErrorResult";
+
+[@bs.module "urql"] external formatDocument: 'a => 'a = "formatDocument";
+
+[@bs.module "urql"] external maskTypename: 'a => 'a = "maskTypename";

--- a/src/hooks/UseQuery.re
+++ b/src/hooks/UseQuery.re
@@ -1,7 +1,16 @@
+type useQueryArgsJs = {
+  query: string,
+  variables: Js.Json.t,
+  requestPolicy: option(string),
+  pollInterval: option(int),
+  context: Types.partialOperationContext,
+  pause: option(bool),
+};
+
 type executeQueryJs = Types.partialOperationContext => unit;
 
 type useQueryResponseJs('extensions) = (
-  Types.jsHookResponse(Js.Json.t, 'extensions),
+  Types.hookResponseJs(Js.Json.t, 'extensions),
   executeQueryJs,
 );
 
@@ -25,17 +34,16 @@ type useQueryResponse('response, 'extensions) = (
   executeQuery,
 );
 
-type useQueryArgs = {
-  query: string,
-  variables: Js.Json.t,
-  requestPolicy: option(string),
-  pause: option(bool),
-  context: Types.partialOperationContext,
-};
-
 [@bs.module "urql"]
-external useQueryJs: useQueryArgs => useQueryResponseJs('extensions) =
+external useQueryJs: useQueryArgsJs => useQueryResponseJs('extensions) =
   "useQuery";
+
+// reason-react does not provide a binding of sufficient arity for our memoization needs
+[@bs.module "react"]
+external useMemo10:
+  ([@bs.uncurry] (unit => 'any), ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j)) =>
+  'any =
+  "useMemo";
 
 let useQuery =
     (
@@ -56,25 +64,50 @@ let useQuery =
   let variables = request##variables;
   let parse = request##parse;
   let rp =
-    UseSemanticGuarantee.useSemanticGuarantee(
-      () => Belt.Option.map(requestPolicy, Types.requestPolicyToJs),
-      requestPolicy,
+    React.useMemo1(
+      () => requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
+      [|requestPolicy|],
     );
-  let context = {
-    Types.partialOperationContext(
-      ~additionalTypenames?,
-      ~fetchOptions?,
-      ~fetch?,
-      ~url?,
-      ~pollInterval?,
-      ~meta?,
-      ~suspense?,
-      ~preferGetMethod?,
-      (),
-    );
-  };
 
-  let args = {query, variables, requestPolicy: rp, pause, context};
+  let client = UseClient.useClient();
+
+  let context =
+    useMemo10(
+      () => {
+        let c: Types.partialOperationContext = {
+          additionalTypenames,
+          fetchOptions,
+          fetch,
+          url: Some(url->Belt.Option.getWithDefault(client.url)),
+          requestPolicy: rp,
+          pollInterval,
+          meta,
+          suspense,
+          preferGetMethod,
+        };
+
+        c;
+      },
+      (
+        additionalTypenames,
+        fetchOptions,
+        fetch,
+        url,
+        client,
+        rp,
+        pollInterval,
+        meta,
+        suspense,
+        preferGetMethod,
+      ),
+    );
+
+  let args =
+    React.useMemo6(
+      () =>
+        {query, variables, requestPolicy: rp, pollInterval, pause, context},
+      (query, variables, rp, pollInterval, pause, context),
+    );
 
   let (stateJs, executeQueryJs) = useQueryJs(args);
 
@@ -99,20 +132,19 @@ let useQuery =
         ~preferGetMethod=?,
         (),
       ) => {
-        let ctx =
-          Types.partialOperationContext(
-            ~additionalTypenames?,
-            ~fetchOptions?,
-            ~fetch?,
-            ~requestPolicy=?
-              Belt.Option.map(requestPolicy, Types.requestPolicyToJs),
-            ~url?,
-            ~pollInterval?,
-            ~meta?,
-            ~suspense?,
-            ~preferGetMethod?,
-            (),
-          );
+        let ctx: Types.partialOperationContext = {
+          additionalTypenames,
+          fetchOptions,
+          fetch,
+          url,
+          requestPolicy:
+            requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
+          pollInterval,
+          meta,
+          suspense,
+          preferGetMethod,
+        };
+
         executeQueryJs(ctx);
       },
       [|executeQueryJs|],


### PR DESCRIPTION
This PR binds the final APIs from `urql` 1.10 that I have slated for addition in #171. These include:

- Add utilities for makeResult, makeErrorResult, formatDocument, and maskTypename.
- Add enableAllOperations option on the subscriptionExchange.
- Add `client.subscription` method.

There was also a change that involved removal of our final `[@bs.deriving abstract]`, `partialOperationContext`. From what I can tell in the new ReScript docs, this is pretty much going away entirely in ReScript, so I decided to plan ahead for it. The big bummer about direct record -> object compilation, however, is that it doesn't really provide a good mechanism for generating `Partial` objects like in TS. We can't define half of these keys on a record, for example – if they're potentially undefined we have to explicitly set their value to `None`. This doesn't translate cleanly to the object spread syntax used in `urql`, because now ReScript will generate a `context` object like:

```js
{
  fetch: undefined,
  fetchOptions: undefined,
  url: undefined,
  requestPolicy: undefined
  // etc.
}
```

that'll overwrite the configuration pulled in by the Client. I'll point these places out in the code if anyone has any solid ideas. From what I can tell, partial object compilation isn't really possible without `[@bs.deriving abstract]`, which feels like the tradeoff for explicitness.