### PR TITLE
Improve handling of potential null values from the JS side.

### DIFF
--- a/__tests__/Types_test.re
+++ b/__tests__/Types_test.re
@@ -35,7 +35,7 @@ describe("Types", () => {
             data: Js.Nullable.undefined,
             error: None,
             extensions: None,
-            stale: None,
+            stale: false,
           };
         let parse = _json => ();
         let result = Types.urqlResponseToReason(~response, ~parse);
@@ -54,7 +54,7 @@ describe("Types", () => {
           data: Js.Nullable.return(Js.Json.string("Hello")),
           error: None,
           extensions: None,
-          stale: None,
+          stale: false,
         };
       let parse = json => Js.Json.decodeString(json);
       let result = Types.urqlResponseToReason(~response, ~parse);
@@ -101,7 +101,7 @@ describe("Types", () => {
             data: Js.Nullable.return(Js.Json.string("Hello")),
             error: Some(errorJs),
             extensions: None,
-            stale: None,
+            stale: false,
           };
 
         let parse = json => Js.Json.decodeString(json);
@@ -151,7 +151,7 @@ describe("Types", () => {
           data: Js.Nullable.undefined,
           error: Some(errorJs),
           extensions: None,
-          stale: None,
+          stale: false,
         };
       let parse = _json => ();
       let result = Types.urqlResponseToReason(~response, ~parse);
@@ -167,7 +167,7 @@ describe("Types", () => {
           data: Js.Nullable.undefined,
           error: None,
           extensions: None,
-          stale: None,
+          stale: false,
         };
       let parse = _json => ();
       let result = Types.urqlResponseToReason(~response, ~parse);

--- a/__tests__/Types_test.re
+++ b/__tests__/Types_test.re
@@ -32,10 +32,10 @@ describe("Types", () => {
           Types.{
             operation: mockOperation,
             fetching: true,
-            data: None,
-            error: None,
-            extensions: None,
-            stale: false,
+            data: Js.Nullable.undefined,
+            error: Js.Nullable.undefined,
+            extensions: Js.Nullable.undefined,
+            stale: Js.Nullable.return(false),
           };
         let parse = _json => ();
         let result = Types.urqlResponseToReason(~response, ~parse);
@@ -51,10 +51,10 @@ describe("Types", () => {
         Types.{
           operation: mockOperation,
           fetching: false,
-          data: Some(Js.Json.string("Hello")),
-          error: None,
-          extensions: None,
-          stale: false,
+          data: Js.Nullable.return(Js.Json.string("Hello")),
+          error: Js.Nullable.undefined,
+          extensions: Js.Nullable.undefined,
+          stale: Js.Nullable.return(false),
         };
       let parse = json => Js.Json.decodeString(json);
       let result = Types.urqlResponseToReason(~response, ~parse);
@@ -98,10 +98,10 @@ describe("Types", () => {
           Types.{
             operation: mockOperation,
             fetching: false,
-            data: Some(Js.Json.string("Hello")),
-            error: Some(errorJs),
-            extensions: None,
-            stale: false,
+            data: Js.Nullable.return(Js.Json.string("Hello")),
+            error: Js.Nullable.return(errorJs),
+            extensions: Js.Nullable.undefined,
+            stale: Js.Nullable.return(false),
           };
 
         let parse = json => Js.Json.decodeString(json);
@@ -148,10 +148,10 @@ describe("Types", () => {
         Types.{
           operation: mockOperation,
           fetching: false,
-          data: None,
-          error: Some(errorJs),
-          extensions: None,
-          stale: false,
+          data: Js.Nullable.undefined,
+          error: Js.Nullable.return(errorJs),
+          extensions: Js.Nullable.undefined,
+          stale: Js.Nullable.return(false),
         };
       let parse = _json => ();
       let result = Types.urqlResponseToReason(~response, ~parse);
@@ -164,10 +164,10 @@ describe("Types", () => {
         Types.{
           operation: mockOperation,
           fetching: false,
-          data: None,
-          error: None,
-          extensions: None,
-          stale: false,
+          data: Js.Nullable.undefined,
+          error: Js.Nullable.undefined,
+          extensions: Js.Nullable.undefined,
+          stale: Js.Nullable.return(false),
         };
       let parse = _json => ();
       let result = Types.urqlResponseToReason(~response, ~parse);

--- a/__tests__/Types_test.re
+++ b/__tests__/Types_test.re
@@ -33,9 +33,9 @@ describe("Types", () => {
             operation: mockOperation,
             fetching: true,
             data: Js.Nullable.undefined,
-            error: Js.Nullable.undefined,
-            extensions: Js.Nullable.undefined,
-            stale: Js.Nullable.return(false),
+            error: None,
+            extensions: None,
+            stale: None,
           };
         let parse = _json => ();
         let result = Types.urqlResponseToReason(~response, ~parse);
@@ -52,9 +52,9 @@ describe("Types", () => {
           operation: mockOperation,
           fetching: false,
           data: Js.Nullable.return(Js.Json.string("Hello")),
-          error: Js.Nullable.undefined,
-          extensions: Js.Nullable.undefined,
-          stale: Js.Nullable.return(false),
+          error: None,
+          extensions: None,
+          stale: None,
         };
       let parse = json => Js.Json.decodeString(json);
       let result = Types.urqlResponseToReason(~response, ~parse);
@@ -99,9 +99,9 @@ describe("Types", () => {
             operation: mockOperation,
             fetching: false,
             data: Js.Nullable.return(Js.Json.string("Hello")),
-            error: Js.Nullable.return(errorJs),
-            extensions: Js.Nullable.undefined,
-            stale: Js.Nullable.return(false),
+            error: Some(errorJs),
+            extensions: None,
+            stale: None,
           };
 
         let parse = json => Js.Json.decodeString(json);
@@ -149,9 +149,9 @@ describe("Types", () => {
           operation: mockOperation,
           fetching: false,
           data: Js.Nullable.undefined,
-          error: Js.Nullable.return(errorJs),
-          extensions: Js.Nullable.undefined,
-          stale: Js.Nullable.return(false),
+          error: Some(errorJs),
+          extensions: None,
+          stale: None,
         };
       let parse = _json => ();
       let result = Types.urqlResponseToReason(~response, ~parse);
@@ -165,9 +165,9 @@ describe("Types", () => {
           operation: mockOperation,
           fetching: false,
           data: Js.Nullable.undefined,
-          error: Js.Nullable.undefined,
-          extensions: Js.Nullable.undefined,
-          stale: Js.Nullable.return(false),
+          error: None,
+          extensions: None,
+          stale: None,
         };
       let parse = _json => ();
       let result = Types.urqlResponseToReason(~response, ~parse);

--- a/src/Client.re
+++ b/src/Client.re
@@ -200,13 +200,11 @@ type clientResponse('response) = {
  * methods to typed a Reason record.
  */
 let urqlClientResponseToReason = (~response: Types.operationResult, ~parse) => {
+  let {extensions, stale}: Types.operationResult = response;
+
   let data = response.data->Js.Nullable.toOption->Belt.Option.map(parse);
   let error =
-    response.error
-    ->Js.Nullable.toOption
-    ->Belt.Option.map(CombinedError.combinedErrorToRecord);
-  let extensions = response.extensions->Js.Nullable.toOption;
-  let stale = response.stale->Js.Nullable.toOption;
+    response.error->Belt.Option.map(CombinedError.combinedErrorToRecord);
 
   let response =
     switch (data, error) {

--- a/src/Client.rei
+++ b/src/Client.rei
@@ -133,7 +133,9 @@ type response('response) =
 type clientResponse('response) = {
   data: option('response),
   error: option(CombinedError.t),
+  extensions: option(Js.Dict.t(string)),
   response: response('response),
+  stale: option(bool),
 };
 
 let urqlClientResponseToReason:

--- a/src/GraphQLError.re
+++ b/src/GraphQLError.re
@@ -12,8 +12,6 @@ type source = {
   locationOffset: sourceLocation,
 };
 
-type extension;
-
 type t = {
   message: string,
   locations: option(array(sourceLocation)),
@@ -22,5 +20,5 @@ type t = {
   source: option(source),
   positions: option(array(int)),
   originalError: option(Js.Exn.t),
-  extensions: option(Js.Dict.t(extension)),
+  extensions: option(Js.Json.t),
 };

--- a/src/GraphQLError.rei
+++ b/src/GraphQLError.rei
@@ -12,8 +12,6 @@ type source = {
   locationOffset: sourceLocation,
 };
 
-type extension;
-
 type t = {
   message: string,
   locations: option(array(sourceLocation)),
@@ -22,5 +20,5 @@ type t = {
   source: option(source),
   positions: option(array(int)),
   originalError: option(Js.Exn.t),
-  extensions: option(Js.Dict.t(extension)),
+  extensions: option(Js.Json.t),
 };

--- a/src/Types.re
+++ b/src/Types.re
@@ -71,9 +71,9 @@ type operation = {
 type operationResult = {
   operation,
   data: Js.Nullable.t(Js.Json.t),
-  error: Js.Nullable.t(CombinedError.combinedErrorJs),
-  extensions: Js.Nullable.t(Js.Dict.t(string)),
-  stale: Js.Nullable.t(bool),
+  error: option(CombinedError.combinedErrorJs),
+  extensions: option(Js.Dict.t(string)),
+  stale: option(bool),
 };
 
 /* The GraphQL request object.
@@ -114,9 +114,9 @@ type hookResponseJs('response, 'extensions) = {
   operation,
   fetching: bool,
   data: Js.Nullable.t('response),
-  error: Js.Nullable.t(CombinedError.combinedErrorJs),
-  extensions: Js.Nullable.t('extensions),
-  stale: Js.Nullable.t(bool),
+  error: option(CombinedError.combinedErrorJs),
+  extensions: option('extensions),
+  stale: option(bool),
 };
 
 /**
@@ -124,15 +124,11 @@ type hookResponseJs('response, 'extensions) = {
  * JavaScript representation to a typed Reason record.
  */
 let urqlResponseToReason = (~response, ~parse) => {
-  let {operation, fetching} = response;
+  let {operation, fetching, extensions, stale} = response;
 
   let data = response.data->Js.Nullable.toOption->Belt.Option.map(parse);
   let error =
-    response.error
-    ->Js.Nullable.toOption
-    ->Belt.Option.map(CombinedError.combinedErrorToRecord);
-  let extensions = response.extensions->Js.Nullable.toOption;
-  let stale = response.stale->Js.Nullable.toOption;
+    response.error->Belt.Option.map(CombinedError.combinedErrorToRecord);
 
   let response =
     switch (fetching, data, error) {

--- a/src/Types.re
+++ b/src/Types.re
@@ -100,22 +100,22 @@ type response('response) =
   | Error(CombinedError.t)
   | Empty;
 
-type hookResponse('response, 'extensions) = {
+type hookResponse('response) = {
   operation,
   fetching: bool,
   data: option('response),
   error: option(CombinedError.t),
   response: response('response),
-  extensions: option('extensions),
+  extensions: option(Js.Json.t),
   stale: bool,
 };
 
-type hookResponseJs('response, 'extensions) = {
+type hookResponseJs('response) = {
   operation,
   fetching: bool,
   data: Js.Nullable.t('response),
   error: option(CombinedError.combinedErrorJs),
-  extensions: option('extensions),
+  extensions: option(Js.Json.t),
   stale: bool,
 };
 
@@ -156,5 +156,4 @@ type graphqlDefinition('parseResult, 'composeReturnType, 'hookReturnType) = (
 type executionResult = {
   errors: option(array(GraphQLError.t)),
   data: option(Js.Json.t),
-  extensions: Js.Json.t,
 };

--- a/src/Types.re
+++ b/src/Types.re
@@ -107,7 +107,7 @@ type hookResponse('response, 'extensions) = {
   error: option(CombinedError.t),
   response: response('response),
   extensions: option('extensions),
-  stale: option(bool),
+  stale: bool,
 };
 
 type hookResponseJs('response, 'extensions) = {
@@ -116,7 +116,7 @@ type hookResponseJs('response, 'extensions) = {
   data: Js.Nullable.t('response),
   error: option(CombinedError.combinedErrorJs),
   extensions: option('extensions),
-  stale: option(bool),
+  stale: bool,
 };
 
 /**

--- a/src/Types.rei
+++ b/src/Types.rei
@@ -90,31 +90,28 @@ type response('response) =
   | Error(CombinedError.t)
   | Empty;
 
-type hookResponse('response, 'extensions) = {
+type hookResponse('response) = {
   operation,
   fetching: bool,
   data: option('response),
   error: option(CombinedError.t),
   response: response('response),
-  extensions: option('extensions),
+  extensions: option(Js.Json.t),
   stale: bool,
 };
 
-type hookResponseJs('response, 'extensions) = {
+type hookResponseJs('response) = {
   operation,
   fetching: bool,
   data: Js.Nullable.t('response),
   error: option(CombinedError.combinedErrorJs),
-  extensions: option('extensions),
+  extensions: option(Js.Json.t),
   stale: bool,
 };
 
 let urqlResponseToReason:
-  (
-    ~response: hookResponseJs(Js.Json.t, 'extensions),
-    ~parse: Js.Json.t => 'response
-  ) =>
-  hookResponse('response, 'extensions);
+  (~response: hookResponseJs(Js.Json.t), ~parse: Js.Json.t => 'response) =>
+  hookResponse('response);
 
 type graphqlDefinition('parseResult, 'composeReturnType, 'hookReturnType) = (
   // `parse`
@@ -130,5 +127,4 @@ type graphqlDefinition('parseResult, 'composeReturnType, 'hookReturnType) = (
 type executionResult = {
   errors: option(array(GraphQLError.t)),
   data: option(Js.Json.t),
-  extensions: Js.Json.t,
 };

--- a/src/Types.rei
+++ b/src/Types.rei
@@ -61,9 +61,9 @@ type operation = {
 type operationResult = {
   operation,
   data: Js.Nullable.t(Js.Json.t),
-  error: Js.Nullable.t(CombinedError.combinedErrorJs),
-  extensions: Js.Nullable.t(Js.Dict.t(string)),
-  stale: Js.Nullable.t(bool),
+  error: option(CombinedError.combinedErrorJs),
+  extensions: option(Js.Dict.t(string)),
+  stale: option(bool),
 };
 
 /* The GraphQL request object.
@@ -104,9 +104,9 @@ type hookResponseJs('response, 'extensions) = {
   operation,
   fetching: bool,
   data: Js.Nullable.t('response),
-  error: Js.Nullable.t(CombinedError.combinedErrorJs),
-  extensions: Js.Nullable.t('extensions),
-  stale: Js.Nullable.t(bool),
+  error: option(CombinedError.combinedErrorJs),
+  extensions: option('extensions),
+  stale: option(bool),
 };
 
 let urqlResponseToReason:

--- a/src/Types.rei
+++ b/src/Types.rei
@@ -60,9 +60,10 @@ type operation = {
 /* The result of the GraphQL operation. */
 type operationResult = {
   operation,
-  data: option(Js.Json.t),
-  error: option(CombinedError.combinedErrorJs),
-  stale: option(bool),
+  data: Js.Nullable.t(Js.Json.t),
+  error: Js.Nullable.t(CombinedError.combinedErrorJs),
+  extensions: Js.Nullable.t(Js.Dict.t(string)),
+  stale: Js.Nullable.t(bool),
 };
 
 /* The GraphQL request object.
@@ -96,16 +97,16 @@ type hookResponse('response, 'extensions) = {
   error: option(CombinedError.t),
   response: response('response),
   extensions: option('extensions),
-  stale: bool,
+  stale: option(bool),
 };
 
 type hookResponseJs('response, 'extensions) = {
   operation,
   fetching: bool,
-  data: option('response),
-  error: option(CombinedError.combinedErrorJs),
-  extensions: option('extensions),
-  stale: bool,
+  data: Js.Nullable.t('response),
+  error: Js.Nullable.t(CombinedError.combinedErrorJs),
+  extensions: Js.Nullable.t('extensions),
+  stale: Js.Nullable.t(bool),
 };
 
 let urqlResponseToReason:

--- a/src/Types.rei
+++ b/src/Types.rei
@@ -97,7 +97,7 @@ type hookResponse('response, 'extensions) = {
   error: option(CombinedError.t),
   response: response('response),
   extensions: option('extensions),
-  stale: option(bool),
+  stale: bool,
 };
 
 type hookResponseJs('response, 'extensions) = {
@@ -106,7 +106,7 @@ type hookResponseJs('response, 'extensions) = {
   data: Js.Nullable.t('response),
   error: option(CombinedError.combinedErrorJs),
   extensions: option('extensions),
-  stale: option(bool),
+  stale: bool,
 };
 
 let urqlResponseToReason:

--- a/src/hooks/Hooks.re
+++ b/src/hooks/Hooks.re
@@ -3,13 +3,13 @@ include UseQuery;
 include UseMutation;
 include UseSubscription;
 
-type hookResponse('ret, 'extensions) =
-  Types.hookResponse('ret, 'extensions) = {
+type hookResponse('ret) =
+  Types.hookResponse('ret) = {
     operation: Types.operation,
     fetching: bool,
     data: option('ret),
     error: option(CombinedError.t),
     response: Types.response('ret),
-    extensions: option('extensions),
+    extensions: option(Js.Json.t),
     stale: bool,
   };

--- a/src/hooks/Hooks.re
+++ b/src/hooks/Hooks.re
@@ -11,5 +11,5 @@ type hookResponse('ret, 'extensions) =
     error: option(CombinedError.t),
     response: Types.response('ret),
     extensions: option('extensions),
-    stale: option(bool),
+    stale: bool,
   };

--- a/src/hooks/Hooks.re
+++ b/src/hooks/Hooks.re
@@ -11,5 +11,5 @@ type hookResponse('ret, 'extensions) =
     error: option(CombinedError.t),
     response: Types.response('ret),
     extensions: option('extensions),
-    stale: bool,
+    stale: option(bool),
   };

--- a/src/hooks/UseMutation.re
+++ b/src/hooks/UseMutation.re
@@ -17,19 +17,18 @@ type executeMutation =
   ) =>
   Js.Promise.t(Types.operationResult);
 
-type useMutationResponseJs('extensions) = (
-  Types.hookResponseJs(Js.Json.t, 'extensions),
+type useMutationResponseJs = (
+  Types.hookResponseJs(Js.Json.t),
   executeMutationJs,
 );
 
-type useMutationResponse('response, 'extensions) = (
-  Types.hookResponse('response, 'extensions),
+type useMutationResponse('response) = (
+  Types.hookResponse('response),
   executeMutation,
 );
 
 [@bs.module "urql"]
-external useMutationJs: string => useMutationResponseJs('extensions) =
-  "useMutation";
+external useMutationJs: string => useMutationResponseJs = "useMutation";
 
 /**
  * The useMutation hook.

--- a/src/hooks/UseMutation.rei
+++ b/src/hooks/UseMutation.rei
@@ -13,14 +13,13 @@ type executeMutation =
   ) =>
   Js.Promise.t(Types.operationResult);
 
-type useMutationResponse('response, 'extensions) = (
-  Types.hookResponse('response, 'extensions),
+type useMutationResponse('response) = (
+  Types.hookResponse('response),
   executeMutation,
 );
 
 let useMutation:
-  (~request: Types.request('response)) =>
-  useMutationResponse('response, 'extensions);
+  (~request: Types.request('response)) => useMutationResponse('response);
 
 let useDynamicMutation:
   Types.graphqlDefinition(
@@ -29,7 +28,7 @@ let useDynamicMutation:
     'executeMutation,
   ) =>
   (
-    Types.hookResponse('parse, 'extensions),
+    Types.hookResponse('parse),
     (
       ~additionalTypenames: array(string)=?,
       ~fetchOptions: Fetch.requestInit=?,

--- a/src/hooks/UseQuery.re
+++ b/src/hooks/UseQuery.re
@@ -9,10 +9,7 @@ type useQueryArgsJs = {
 
 type executeQueryJs = Types.partialOperationContext => unit;
 
-type useQueryResponseJs('extensions) = (
-  Types.hookResponseJs(Js.Json.t, 'extensions),
-  executeQueryJs,
-);
+type useQueryResponseJs = (Types.hookResponseJs(Js.Json.t), executeQueryJs);
 
 type executeQuery =
   (
@@ -29,14 +26,13 @@ type executeQuery =
   ) =>
   unit;
 
-type useQueryResponse('response, 'extensions) = (
-  Types.hookResponse('response, 'extensions),
+type useQueryResponse('response) = (
+  Types.hookResponse('response),
   executeQuery,
 );
 
 [@bs.module "urql"]
-external useQueryJs: useQueryArgsJs => useQueryResponseJs('extensions) =
-  "useQuery";
+external useQueryJs: useQueryArgsJs => useQueryResponseJs = "useQuery";
 
 // reason-react does not provide a binding of sufficient arity for our memoization needs
 [@bs.module "react"]

--- a/src/hooks/UseQuery.rei
+++ b/src/hooks/UseQuery.rei
@@ -13,8 +13,8 @@ type executeQuery =
   ) =>
   unit;
 
-type useQueryResponse('response, 'extensions) = (
-  Types.hookResponse('response, 'extensions),
+type useQueryResponse('response) = (
+  Types.hookResponse('response),
   executeQuery,
 );
 
@@ -33,4 +33,4 @@ let useQuery:
     ~preferGetMethod: bool=?,
     unit
   ) =>
-  useQueryResponse('response, 'extensions);
+  useQueryResponse('response);

--- a/src/hooks/UseSubscription.re
+++ b/src/hooks/UseSubscription.re
@@ -20,7 +20,7 @@ type executeSubscriptionJs = Types.partialOperationContext => unit;
 [@bs.module "urql"]
 external useSubscriptionJs:
   (useSubscriptionArgs, option((option('acc), Js.Json.t) => 'acc)) =>
-  (Types.hookResponseJs('ret, 'extensions), executeSubscriptionJs) =
+  (Types.hookResponseJs('ret), executeSubscriptionJs) =
   "useSubscription";
 
 type executeSubscription =
@@ -38,13 +38,12 @@ type executeSubscription =
   ) =>
   unit;
 
-type useSubscriptionResponse('response, 'extensions) = (
-  Types.hookResponse('response, 'extensions),
+type useSubscriptionResponse('response) = (
+  Types.hookResponse('response),
   executeSubscription,
 );
 
-let subscriptionResponseToReason =
-    (response: Types.hookResponseJs('ret, 'extensions)) => {
+let subscriptionResponseToReason = (response: Types.hookResponseJs('ret)) => {
   let Types.{operation, fetching, extensions, stale} = response;
 
   let data = response.data->Js.Nullable.toOption;

--- a/src/hooks/UseSubscription.re
+++ b/src/hooks/UseSubscription.re
@@ -44,11 +44,16 @@ type useSubscriptionResponse('response, 'extensions) = (
 );
 
 let subscriptionResponseToReason =
-    (result: Types.hookResponseJs('ret, 'extensions)) => {
-  let data = result.data;
+    (response: Types.hookResponseJs('ret, 'extensions)) => {
+  let Types.{operation, fetching} = response;
+
+  let data = response.data->Js.Nullable.toOption;
   let error =
-    result.error->Belt.Option.map(CombinedError.combinedErrorToRecord);
-  let Types.{operation, fetching, extensions, stale} = result;
+    response.error
+    ->Js.Nullable.toOption
+    ->Belt.Option.map(CombinedError.combinedErrorToRecord);
+  let extensions = response.extensions->Js.Nullable.toOption;
+  let stale = response.stale->Js.Nullable.toOption;
 
   let response =
     switch (fetching, data, error) {

--- a/src/hooks/UseSubscription.re
+++ b/src/hooks/UseSubscription.re
@@ -45,15 +45,11 @@ type useSubscriptionResponse('response, 'extensions) = (
 
 let subscriptionResponseToReason =
     (response: Types.hookResponseJs('ret, 'extensions)) => {
-  let Types.{operation, fetching} = response;
+  let Types.{operation, fetching, extensions, stale} = response;
 
   let data = response.data->Js.Nullable.toOption;
   let error =
-    response.error
-    ->Js.Nullable.toOption
-    ->Belt.Option.map(CombinedError.combinedErrorToRecord);
-  let extensions = response.extensions->Js.Nullable.toOption;
-  let stale = response.stale->Js.Nullable.toOption;
+    response.error->Belt.Option.map(CombinedError.combinedErrorToRecord);
 
   let response =
     switch (fetching, data, error) {

--- a/src/hooks/UseSubscription.rei
+++ b/src/hooks/UseSubscription.rei
@@ -18,8 +18,8 @@ type executeSubscription =
   ) =>
   unit;
 
-type useSubscriptionResponse('response, 'extensions) = (
-  Types.hookResponse('response, 'extensions),
+type useSubscriptionResponse('response) = (
+  Types.hookResponse('response),
   executeSubscription,
 );
 
@@ -39,4 +39,4 @@ let useSubscription:
     ~preferGetMethod: bool=?,
     unit
   ) =>
-  useSubscriptionResponse('ret, 'extensions);
+  useSubscriptionResponse('ret);


### PR DESCRIPTION
This PR attempts to fix #202

@gaku-sei I'd love your 👀 here. The main gist of the changes:

- Treat all fields on `operationResult` as `Js.Nullable.t`s except for `operation` (which is guaranteed to be defined).
- Ensure we convert `Js.Nullable` values like `data`, `error`, `extensions`, and `stale` to `option` before operating on them.

I read your comment in #202 and agree that it's a bit uncertain where we really need the `Js.Nullable` value. From my perspective, I know that `urql` generally does a good job avoiding passing `null` in its internals, so direct `option` compilation to handle `undefined` feels ok for most cases. But agree that anything being passed through from the GraphQL server should be treated with a bit more caution.