### PR TITLE
Revert to using bs.deriving abstract for partialOperationContext.

### DIFF
--- a/src/Client.re
+++ b/src/Client.re
@@ -247,17 +247,19 @@ let executeQuery =
       (),
     );
   let parse = request##parse;
-  let optsJs: Types.partialOperationContext = {
-    additionalTypenames,
-    fetchOptions,
-    fetch,
-    requestPolicy: requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
-    url: Some(url->Belt.Option.getWithDefault(client.url)),
-    pollInterval,
-    meta,
-    suspense,
-    preferGetMethod,
-  };
+  let optsJs =
+    Types.partialOperationContext(
+      ~additionalTypenames?,
+      ~fetchOptions?,
+      ~fetch?,
+      ~requestPolicy=?requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
+      ~url?,
+      ~pollInterval?,
+      ~meta?,
+      ~suspense?,
+      ~preferGetMethod?,
+      (),
+    );
 
   executeQueryJs(~client, ~query=req, ~opts=optsJs, ())
   |> Wonka.map((. response) => urqlClientResponseToReason(~response, ~parse));
@@ -296,17 +298,19 @@ let executeMutation =
       (),
     );
   let parse = request##parse;
-  let optsJs: Types.partialOperationContext = {
-    additionalTypenames,
-    fetchOptions,
-    fetch,
-    requestPolicy: requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
-    url: Some(url->Belt.Option.getWithDefault(client.url)),
-    pollInterval,
-    meta,
-    suspense,
-    preferGetMethod,
-  };
+  let optsJs =
+    Types.partialOperationContext(
+      ~additionalTypenames?,
+      ~fetchOptions?,
+      ~fetch?,
+      ~requestPolicy=?requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
+      ~url?,
+      ~pollInterval?,
+      ~meta?,
+      ~suspense?,
+      ~preferGetMethod?,
+      (),
+    );
 
   executeMutationJs(~client, ~mutation=req, ~opts=optsJs, ())
   |> Wonka.map((. response) => urqlClientResponseToReason(~response, ~parse));
@@ -345,17 +349,19 @@ let executeSubscription =
       (),
     );
   let parse = request##parse;
-  let optsJs: Types.partialOperationContext = {
-    additionalTypenames,
-    fetchOptions,
-    fetch,
-    requestPolicy: requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
-    url: Some(url->Belt.Option.getWithDefault(client.url)),
-    pollInterval,
-    meta,
-    suspense,
-    preferGetMethod,
-  };
+  let optsJs =
+    Types.partialOperationContext(
+      ~additionalTypenames?,
+      ~fetchOptions?,
+      ~fetch?,
+      ~requestPolicy=?requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
+      ~url?,
+      ~pollInterval?,
+      ~meta?,
+      ~suspense?,
+      ~preferGetMethod?,
+      (),
+    );
 
   executeSubscriptionJs(~client, ~subscription=req, ~opts=optsJs, ())
   |> Wonka.map((. response) => urqlClientResponseToReason(~response, ~parse));

--- a/src/Types.re
+++ b/src/Types.re
@@ -46,16 +46,26 @@ type operationContext = {
   preferGetMethod: option(bool),
 };
 
+[@bs.deriving {abstract: light}]
 type partialOperationContext = {
-  additionalTypenames: option(array(string)),
-  fetch: option((string, Fetch.requestInit) => Js.Promise.t(Fetch.response)),
-  fetchOptions: option(Fetch.requestInit),
-  requestPolicy: option(string),
-  url: option(string),
-  pollInterval: option(int),
-  meta: option(operationDebugMeta),
-  suspense: option(bool),
-  preferGetMethod: option(bool),
+  [@bs.optional]
+  additionalTypenames: array(string),
+  [@bs.optional]
+  fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response),
+  [@bs.optional]
+  fetchOptions: Fetch.requestInit,
+  [@bs.optional]
+  requestPolicy: string,
+  [@bs.optional]
+  url: string,
+  [@bs.optional]
+  pollInterval: int,
+  [@bs.optional]
+  meta: operationDebugMeta,
+  [@bs.optional]
+  suspense: bool,
+  [@bs.optional]
+  preferGetMethod: bool,
 };
 
 /* The active GraphQL operation. */

--- a/src/Types.rei
+++ b/src/Types.rei
@@ -36,16 +36,26 @@ type operationContext = {
   preferGetMethod: option(bool),
 };
 
+[@bs.deriving {abstract: light}]
 type partialOperationContext = {
-  additionalTypenames: option(array(string)),
-  fetch: option((string, Fetch.requestInit) => Js.Promise.t(Fetch.response)),
-  fetchOptions: option(Fetch.requestInit),
-  requestPolicy: option(string),
-  url: option(string),
-  pollInterval: option(int),
-  meta: option(operationDebugMeta),
-  suspense: option(bool),
-  preferGetMethod: option(bool),
+  [@bs.optional]
+  additionalTypenames: array(string),
+  [@bs.optional]
+  fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response),
+  [@bs.optional]
+  fetchOptions: Fetch.requestInit,
+  [@bs.optional]
+  requestPolicy: string,
+  [@bs.optional]
+  url: string,
+  [@bs.optional]
+  pollInterval: int,
+  [@bs.optional]
+  meta: operationDebugMeta,
+  [@bs.optional]
+  suspense: bool,
+  [@bs.optional]
+  preferGetMethod: bool,
 };
 
 /* The active GraphQL operation. */

--- a/src/hooks/UseMutation.re
+++ b/src/hooks/UseMutation.re
@@ -44,8 +44,6 @@ let useMutation = (~request) => {
   let variables = request##variables;
   let parse = request##parse;
 
-  let client = UseClient.useClient();
-
   let (stateJs, executeMutationJs) = useMutationJs(query);
 
   let state =
@@ -55,7 +53,7 @@ let useMutation = (~request) => {
     );
 
   let executeMutation =
-    React.useMemo3(
+    React.useMemo2(
       (
         (),
         ~additionalTypenames=?,
@@ -69,22 +67,24 @@ let useMutation = (~request) => {
         ~preferGetMethod=?,
         (),
       ) => {
-        let ctx: Types.partialOperationContext = {
-          additionalTypenames,
-          fetchOptions,
-          fetch,
-          requestPolicy:
-            requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
-          url: Some(url->Belt.Option.getWithDefault(client.url)),
-          pollInterval,
-          meta,
-          suspense,
-          preferGetMethod,
-        };
+        let ctx =
+          Types.partialOperationContext(
+            ~additionalTypenames?,
+            ~fetchOptions?,
+            ~fetch?,
+            ~url?,
+            ~requestPolicy=?
+              requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
+            ~pollInterval?,
+            ~meta?,
+            ~suspense?,
+            ~preferGetMethod?,
+            (),
+          );
 
         executeMutationJs(variables, ctx);
       },
-      (executeMutationJs, variables, client),
+      (executeMutationJs, variables),
     );
 
   (state, executeMutation);
@@ -103,8 +103,6 @@ let useDynamicMutation = definition => {
   let (parse, query, composeVariables) = definition;
   let (stateJs, executeMutationJs) = useMutationJs(query);
 
-  let client = UseClient.useClient();
-
   let state =
     React.useMemo2(
       () => Types.urqlResponseToReason(~response=stateJs, ~parse),
@@ -123,17 +121,20 @@ let useDynamicMutation = definition => {
         ~suspense=?,
         ~preferGetMethod=?,
       ) => {
-    let ctx: Types.partialOperationContext = {
-      additionalTypenames,
-      fetchOptions,
-      fetch,
-      requestPolicy: requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
-      url: Some(url->Belt.Option.getWithDefault(client.url)),
-      pollInterval,
-      meta,
-      suspense,
-      preferGetMethod,
-    };
+    let ctx =
+      Types.partialOperationContext(
+        ~additionalTypenames?,
+        ~fetchOptions?,
+        ~fetch?,
+        ~url?,
+        ~requestPolicy=?
+          requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
+        ~pollInterval?,
+        ~meta?,
+        ~suspense?,
+        ~preferGetMethod?,
+        (),
+      );
 
     composeVariables(variables => executeMutationJs(variables, ctx));
   };

--- a/src/hooks/UseQuery.re
+++ b/src/hooks/UseQuery.re
@@ -40,9 +40,8 @@ external useQueryJs: useQueryArgsJs => useQueryResponseJs('extensions) =
 
 // reason-react does not provide a binding of sufficient arity for our memoization needs
 [@bs.module "react"]
-external useMemo10:
-  ([@bs.uncurry] (unit => 'any), ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j)) =>
-  'any =
+external useMemo9:
+  ([@bs.uncurry] (unit => 'any), ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i)) => 'any =
   "useMemo";
 
 let useQuery =
@@ -69,31 +68,26 @@ let useQuery =
       [|requestPolicy|],
     );
 
-  let client = UseClient.useClient();
-
   let context =
-    useMemo10(
-      () => {
-        let c: Types.partialOperationContext = {
-          additionalTypenames,
-          fetchOptions,
-          fetch,
-          url: Some(url->Belt.Option.getWithDefault(client.url)),
-          requestPolicy: rp,
-          pollInterval,
-          meta,
-          suspense,
-          preferGetMethod,
-        };
-
-        c;
-      },
+    useMemo9(
+      () =>
+        Types.partialOperationContext(
+          ~additionalTypenames?,
+          ~fetchOptions?,
+          ~fetch?,
+          ~url?,
+          ~requestPolicy=?rp,
+          ~pollInterval?,
+          ~meta?,
+          ~suspense?,
+          ~preferGetMethod?,
+          (),
+        ),
       (
         additionalTypenames,
         fetchOptions,
         fetch,
         url,
-        client,
         rp,
         pollInterval,
         meta,
@@ -132,18 +126,20 @@ let useQuery =
         ~preferGetMethod=?,
         (),
       ) => {
-        let ctx: Types.partialOperationContext = {
-          additionalTypenames,
-          fetchOptions,
-          fetch,
-          url,
-          requestPolicy:
-            requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
-          pollInterval,
-          meta,
-          suspense,
-          preferGetMethod,
-        };
+        let ctx =
+          Types.partialOperationContext(
+            ~additionalTypenames?,
+            ~fetchOptions?,
+            ~fetch?,
+            ~url?,
+            ~requestPolicy=?
+              requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
+            ~pollInterval?,
+            ~meta?,
+            ~suspense?,
+            ~preferGetMethod?,
+            (),
+          );
 
         executeQueryJs(ctx);
       },

--- a/src/hooks/UseSubscription.re
+++ b/src/hooks/UseSubscription.re
@@ -64,9 +64,8 @@ let subscriptionResponseToReason =
 
 // reason-react does not provide a binding of sufficient arity for our memoization needs
 [@bs.module "react"]
-external useMemo10:
-  ([@bs.uncurry] (unit => 'any), ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j)) =>
-  'any =
+external useMemo9:
+  ([@bs.uncurry] (unit => 'any), ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i)) => 'any =
   "useMemo";
 
 let useSubscription =
@@ -97,31 +96,26 @@ let useSubscription =
       [|requestPolicy|],
     );
 
-  let client = UseClient.useClient();
-
   let context =
-    useMemo10(
-      () => {
-        let c: Types.partialOperationContext = {
-          additionalTypenames,
-          fetchOptions,
-          fetch,
-          url: Some(url->Belt.Option.getWithDefault(client.url)),
-          requestPolicy: rp,
-          pollInterval,
-          meta,
-          suspense,
-          preferGetMethod,
-        };
-
-        c;
-      },
+    useMemo9(
+      () =>
+        Types.partialOperationContext(
+          ~additionalTypenames?,
+          ~fetchOptions?,
+          ~fetch?,
+          ~url?,
+          ~requestPolicy=?rp,
+          ~pollInterval?,
+          ~meta?,
+          ~suspense?,
+          ~preferGetMethod?,
+          (),
+        ),
       (
         additionalTypenames,
         fetchOptions,
         fetch,
         url,
-        client,
         rp,
         pollInterval,
         meta,
@@ -166,18 +160,20 @@ let useSubscription =
         ~preferGetMethod=?,
         (),
       ) => {
-        let ctx: Types.partialOperationContext = {
-          additionalTypenames,
-          fetchOptions,
-          fetch,
-          url,
-          requestPolicy:
-            requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
-          pollInterval,
-          meta,
-          suspense,
-          preferGetMethod,
-        };
+        let ctx =
+          Types.partialOperationContext(
+            ~additionalTypenames?,
+            ~fetchOptions?,
+            ~fetch?,
+            ~url?,
+            ~requestPolicy=?
+              requestPolicy->Belt.Option.map(Types.requestPolicyToJs),
+            ~pollInterval?,
+            ~meta?,
+            ~suspense?,
+            ~preferGetMethod?,
+            (),
+          );
 
         executeSubscriptionJs(ctx);
       },


### PR DESCRIPTION
Fix #215 

This PR ensures that `partialOperationContext` always returns a truly "partial" object. Using direct object -> record compilation is problematic for this case, because `None` will compile to `undefined` and wipe out defaults if the compiled object is being used with object spread syntax.

@gaku-sei this should fix your issues, because the compiled context objects will only include keys for properties that are passed in the labeled arguments for `executeQuery` as `Some(value)`.