### PR TITLE
feat: modify Client API to place variables in last positional argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-19-orange.svg)](#contributors)
 [![Build Status](https://travis-ci.com/FormidableLabs/reason-urql.svg?branch=master)](https://travis-ci.com/FormidableLabs/reason-urql)
 [![Maintenance Status][maintenance-image]](#maintenance-status)
-[![Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/urql)
 
 Reason bindings for Formidable's Universal React Query Library, [`urql`](https://github.com/FormidableLabs/urql).
 
@@ -21,40 +20,50 @@ Reason bindings for Formidable's Universal React Query Library, [`urql`](https:/
 ## 📋 Documentation
 
 - [Getting Started](/docs/getting-started.md)
-- [API](/docs)
+- [Client and Provider](/docs/client-and-provider.md)
+- [Hooks](/docs/hooks.md)
+- [Exchanges](/docs/exchanges.md)
+- [Errors](/docs/error.md)
+- [Advanced](/docs/advanced.md)
 
 ## 💾 Installation
 
-#### 1. Install `reason-urql`.
+#### 1. Install `reason-urql` and its `peerDependencies`.
 
 ```sh
-yarn add reason-urql
+yarn add reason-urql urql graphql
 ```
 
-#### 2. Add `graphql_ppx_re`.
+We try to keep our bindings as close to latest `urql` as possible. However, `urql` tends to make releases a bit ahead of `reason-urql`. To get a compatible version, we recommend always staying strictly within this project's `peerDependency` range for `urql`.
 
-To get the most out of compile time type checks for your GraphQL queries, mutations, and subscriptions, we recommend using [`graphql_ppx_re`](https://github.com/reasonml-community/graphql_ppx). `useDynamicMutation` in particular takes advantage of some of its internals for an excellent experience writing type safe code to access your GraphQL responses.
+#### 2. Add `@reasonml-community/graphql-ppx`.
+
+To get the most out of compile time type checks for your GraphQL queries, mutations, and subscriptions, we use [`@reasonml-community/graphql-ppx`](https://github.com/reasonml-community/graphql-ppx). Add this to your project's `devDependencies`.
 
 ```sh
-yarn add @baransu/graphql_ppx_re --dev
+yarn add @reasonml-community/graphql-ppx --dev
 ```
 
 #### 3. Update `bsconfig.json`.
 
-Add `reason-urql` to your `bs-dependencies` and `graphql_ppx_re` to your `ppx_flags` in `bsconfig.json`.
+Add `reason-urql`, `wonka`, and `@reasonml-community/graphql-ppx` to your `bs-dependencies` and `@reasonml-community/graphql-ppx/ppx` to your `ppx_flags` in `bsconfig.json`.
 
 ```json
 {
-  "bs-dependencies": ["reason-urql"],
-  "ppx-flags": ["@baransu/graphql_ppx_re/ppx"]
+  "bs-dependencies": [
+    "reason-urql",
+    "wonka",
+    "@reasonml-community/graphql-ppx"
+  ],
+  "ppx-flags": ["@reasonml-community/graphql-ppx/ppx"]
 }
 ```
 
 #### 4. Send an introspection query to your API.
 
-Finally, you'll need to send an introspection query to your GraphQl API, using a tool like [`graphql-cli`](https://github.com/Urigo/graphql-cli/). You should generate a file called `graphql_schema.json` at the root of your project that `graphql_ppx_re` can use to type check your queries. **You should check this file into version control** and keep it updated as your API changes.
+Finally, you'll need to send an introspection query to your GraphQl API, using a tool like [`graphql-cli`](https://github.com/Urigo/graphql-cli/). You should generate a file called `graphql_schema.json` at the root of your project that `graphql-ppx` can use to type check your queries. **You should check this file into version control** and keep it updated as your API changes.
 
-For additional instructions, head [here](https://github.com/reasonml-community/graphql_ppx#usage).
+For additional help, head [here](https://github.com/reasonml-community/graphql-ppx#schema).
 
 ```sh
 npx get-graphql-schema ENDPOINT_URL -j > graphql_schema.json
@@ -146,6 +155,7 @@ This project follows the [all contributors spec](https://github.com/kentcdodds/a
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ## Maintenance Status

--- a/__tests__/Types_test.re
+++ b/__tests__/Types_test.re
@@ -19,17 +19,17 @@ let mockOperation =
     key: 1,
     query: "query {\ndogs {\nname\nlikes\n}\n}",
     variables: None,
-    operationName: `Query,
+    kind: `Query,
     context: mockOperationContext,
   };
 
 describe("Types", () => {
-  describe("urqlResponseToReason", () => {
+  describe("hookResponseToReason", () => {
     it(
       "should correctly return Fetching constructor if fetching is true and no data has been received",
       () => {
         let response =
-          Types.{
+          Types.Hooks.{
             operation: mockOperation,
             fetching: true,
             data: Js.Nullable.undefined,
@@ -38,9 +38,9 @@ describe("Types", () => {
             stale: false,
           };
         let parse = _json => ();
-        let result = Types.urqlResponseToReason(~response, ~parse);
+        let result = Types.Hooks.hookResponseToReason(~response, ~parse);
 
-        Expect.(expect(result.response) |> toEqual(Types.Fetching));
+        Expect.(expect(result.response) |> toEqual(Types.Hooks.Fetching));
       },
     );
 
@@ -48,7 +48,7 @@ describe("Types", () => {
       "should return Data constructor if the GraphQL API responded with data",
       () => {
       let response =
-        Types.{
+        Types.Hooks.{
           operation: mockOperation,
           fetching: false,
           data: Js.Nullable.return(Js.Json.string("Hello")),
@@ -57,10 +57,10 @@ describe("Types", () => {
           stale: false,
         };
       let parse = json => Js.Json.decodeString(json);
-      let result = Types.urqlResponseToReason(~response, ~parse);
+      let result = Types.Hooks.hookResponseToReason(~response, ~parse);
 
       Expect.(
-        expect(result.response) |> toEqual(Types.Data(Some("Hello")))
+        expect(result.response) |> toEqual(Types.Hooks.Data(Some("Hello")))
       );
     });
 
@@ -95,7 +95,7 @@ describe("Types", () => {
           };
 
         let response =
-          Types.{
+          Types.Hooks.{
             operation: mockOperation,
             fetching: false,
             data: Js.Nullable.return(Js.Json.string("Hello")),
@@ -105,11 +105,13 @@ describe("Types", () => {
           };
 
         let parse = json => Js.Json.decodeString(json);
-        let result = Types.urqlResponseToReason(~response, ~parse);
+        let result = Types.Hooks.hookResponseToReason(~response, ~parse);
 
         Expect.(
           expect(result.response)
-          |> toEqual(Types.PartialData(Some("Hello"), error.graphQLErrors))
+          |> toEqual(
+               Types.Hooks.PartialData(Some("Hello"), error.graphQLErrors),
+             )
         );
       },
     );
@@ -145,7 +147,7 @@ describe("Types", () => {
         };
 
       let response =
-        Types.{
+        Types.Hooks.{
           operation: mockOperation,
           fetching: false,
           data: Js.Nullable.undefined,
@@ -154,14 +156,14 @@ describe("Types", () => {
           stale: false,
         };
       let parse = _json => ();
-      let result = Types.urqlResponseToReason(~response, ~parse);
+      let result = Types.Hooks.hookResponseToReason(~response, ~parse);
 
-      Expect.(expect(result.response) |> toEqual(Types.Error(error)));
+      Expect.(expect(result.response) |> toEqual(Types.Hooks.Error(error)));
     });
 
     it("should return Empty constructor if none of the above apply", () => {
       let response =
-        Types.{
+        Types.Hooks.{
           operation: mockOperation,
           fetching: false,
           data: Js.Nullable.undefined,
@@ -170,9 +172,9 @@ describe("Types", () => {
           stale: false,
         };
       let parse = _json => ();
-      let result = Types.urqlResponseToReason(~response, ~parse);
+      let result = Types.Hooks.hookResponseToReason(~response, ~parse);
 
-      Expect.(expect(result.response) |> toEqual(Types.Empty));
+      Expect.(expect(result.response) |> toEqual(Types.Hooks.Empty));
     });
   })
 });

--- a/docs/client-and-provider.md
+++ b/docs/client-and-provider.md
@@ -40,14 +40,16 @@ let client = Client.make(~url="https://localhost:3000/graphql", ());
 
 `Client.make` accepts the following arguments:
 
-| Argument        | Type                          | Description                                                                                                                                                                                                                                                                   |
-| --------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `url`           | `string`                      | The url of your GraphQL API.                                                                                                                                                                                                                                                  |
-| `fetchOptions`  | `Client.fetchOptions('a)=?`   | Optional. A variant type representing fetch options to be used by your client. You can pass your `fetchOptions` as a plain `Fetch.requestInit` by wrapping it in the `Client.FetchOpts` tag, or instantiate it dynamically in a function wrapped by the `Client.FetchFn` tag. |
-| `exchanges`     | `array(Exchanges.exchange)=?` | Optional. The array of exchanges to be used by your client.                                                                                                                                                                                                                   |
-| `suspense`      | `bool=?`                      | Optional. A flag activating the experimental React suspense mode, which can be used during server-side rendering to prefetch data. Defaults to `false`.                                                                                                                       |
-| `fetch`         | `fetchImpl('a)=?`             | Optional. A custom `fetch` implementation to use in lieu of `window.fetch`. For now, see [`__tests__/UrqlClient_test.re`](../__tests__/UrqlClient_test.re) for examples of how to use this option.                                                                            |
-| `requestPolicy` | `Types.requestPolicy=?`       | Optional. A polymorphic variant defining the default `requestPolicy` to use for all outgoing requests. Defaults to CacheFirst. Additional options include CacheOnly, NetworkOnly, and CacheAndNetwork. See [`Types.rei`](../src/Types.rei) for the full definition.           |
+| Argument          | Type                          | Description                                                                                                                                                                                                                                                                   |
+| ----------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`             | `string`                      | The url of your GraphQL API.                                                                                                                                                                                                                                                  |
+| `fetchOptions`    | `Client.fetchOptions('a)=?`   | Optional. A variant type representing fetch options to be used by your client. You can pass your `fetchOptions` as a plain `Fetch.requestInit` by wrapping it in the `Client.FetchOpts` tag, or instantiate it dynamically in a function wrapped by the `Client.FetchFn` tag. |
+| `fetch`           | `fetchImpl('a)=?`             | Optional. A custom `fetch` implementation to use in lieu of `window.fetch`. For now, see [`__tests__/UrqlClient_test.re`](../__tests__/UrqlClient_test.re) for examples of how to use this option.                                                                            |
+| `exchanges`       | `array(Exchanges.exchange)=?` | Optional. The array of exchanges to be used by your client.                                                                                                                                                                                                                   |
+| `suspense`        | `bool=?`                      | Optional. A flag activating the experimental React suspense mode, which can be used during server-side rendering to prefetch data. Defaults to `false`.                                                                                                                       |
+| `requestPolicy`   | `Types.requestPolicy=?`       | Optional. A polymorphic variant defining the default `requestPolicy` to use for all outgoing requests. Defaults to CacheFirst. Additional options include CacheOnly, NetworkOnly, and CacheAndNetwork. See [`Types.rei`](../src/Types.rei) for the full definition.           |
+| `preferGetMethod` | `bool=?`                      | Optional. If `true`, will use the HTTP GET method rather than POST for operations of type `query`. Defaults to `false`.                                                                                                                                                       |
+| `maskTypename`    | `bool=?`                      | Optional. If `true`, will apply the `maskTypename` utility to `data` returned on all operations. This makes the `__typename` properties non-enumerable.                                                                                                                       |
 
 `Client.make` will return an instance of an `urql` client, represented by the abstract type `Client.t`.
 
@@ -68,7 +70,6 @@ open ReasonUrql;
 
 let fetchOptions =
   Client.FetchOpts(Fetch.RequestInit.make(
-    ~method_=Post,
     ~headers=Fetch.HeadersInit.make({"Content-Type": "application/json"}),
     (),
   ));
@@ -109,21 +110,25 @@ let client = Client.make(
 
 Imperatively execute a GraphQL query operation.
 
-| Argument        | Type                         | Description                                                                                                                                                                                                                                                             |
-| --------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `client`        | `Client.t`                   | The `urql` client instance.                                                                                                                                                                                                                                             |
-| `request`       | `Types.request`              | The `graphql_ppx` request representing your query. Generated by calling `.make()` on the `graphql_ppx` module. If you're not using `graphql_ppx`, pass a `Js.t` of the following shape: `{. "query": string, "variables": Js.Json.t, "parse": Js.Json.t => 'response }` |
-| `fetchOptions`  | `Fetch.requestInit=?`        | Optional. The fetch options to apply on the outgoing request.                                                                                                                                                                                                           |
-| `requestPolicy` | `Types.requestPolicy=?`      | Optional. The request policy to use to execute the query. Defaults to `"cache-first"`.                                                                                                                                                                                  |
-| `url`           | `string=?`                   | Optional. The GraphQL endpoint to use for the executing operation (if different from the one specified by `Client.make`).                                                                                                                                               |
-| `pollInterval`  | `int=?`                      | Optional. Instructs the client to reexecute the query every `pollInterval` milliseconds.                                                                                                                                                                                |
-| `meta`          | `Types.operationDebugMeta=?` | Optional. Add metadata that is only available in development with devtools.                                                                                                                                                                                             |
+| Argument              | Type                          | Description                                                                                                                                             |
+| --------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client`              | `Client.t`                    | The `urql` client instance.                                                                                                                             |
+| `query`               | `(module Types.Operation)`    | The `graphql_ppx` module representing your GraphQL operation.                                                                                           |
+| `additionalTypenames` | `array(string)=?`             | Optional. Flag that this operation depends on certain `__typename`s. Used by default in the document cache.                                             |
+| `fetchOptions`        | `Fetch.requestInit=?`         | Optional. The fetch options to apply on the outgoing request.                                                                                           |
+| `requestPolicy`       | `Types.requestPolicy=?`       | Optional. The request policy to use to execute the query. Defaults to `"cache-first"`.                                                                  |
+| `url`                 | `string=?`                    | Optional. The GraphQL endpoint to use for the executing operation (if different from the one specified by `Client.make`).                               |
+| `pollInterval`        | `int=?`                       | Optional. Instructs the client to reexecute the query every `pollInterval` milliseconds.                                                                |
+| `meta`                | `Types.operationDebugMeta=?`  | Optional. Add metadata that is only available in development with devtools.                                                                             |
+| `suspense`            | `bool=?`                      | Optional. A flag activating the experimental React suspense mode, which can be used during server-side rendering to prefetch data. Defaults to `false`. |
+| `preferGetMethod`     | `bool=?`                      | Optional. If `true`, will use the HTTP GET method rather than POST for operations of type `query`. Defaults to `false`.                                 |
+| `variables`           | `Types.Operation.t_variables` | Optional. Variables to pass as part of your GraphQL query. This should be passed as the last positional argument, if needed.                            |
 
-`client.executeQuery` returns a [`wonka` `source`](https://wonka.kitten.sh/api/sources) containing the results of executing the query. The result record has a variant type called `response` with constructors for `Data(d)`, `Error(e)`, and `Empty`, in addition to `data` and `error` fields for accessing the raw response values if desired.
+`client.executeQuery` returns a [`wonka` `source`](https://wonka.kitten.sh/api/sources) containing the results of executing the query. The result record has a variant type called `response` with constructors for `Data(d)`, `PartialData(d, e)`, `Error(e)`, and `Empty`, in addition to `data` and `error` fields for accessing the raw response values if desired.
 
-| Return                                                  | Description                                                                                                                             |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `Wonka.Types.sourceT(Client.clientResponse('response))` | A `wonka` `source` containing a record of the results of query execution. Use the `response` field on this record for pattern matching. |
+| Return                                              | Description                                                                                                                             |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `Wonka.Types.sourceT(Client.clientResponse('data))` | A `wonka` `source` containing a record of the results of query execution. Use the `response` field on this record for pattern matching. |
 
 #### Example
 
@@ -144,7 +149,7 @@ module GetAllDogs = [%graphql
 |}
 ];
 
-Client.executeQuery(~client, ~request=GetAllDogs.make(), ())
+Client.executeQuery(~client, ~query=(module GetAllDogs), ())
   |> Wonka.subscribe((. data) => {
     switch(Client.(data.response)) {
       | Data(d) => /* Access data returned from executing the request. */
@@ -156,23 +161,11 @@ Client.executeQuery(~client, ~request=GetAllDogs.make(), ())
 
 ### `Client.query`
 
-The same as `Client.executeQuery`, but returns a `Js.Promise.t` rather than a `wonka` `source`.
+The same as `Client.executeQuery`, but returns a `Js.Promise.t` rather than a `wonka` `source`. This method accepts all of the same arguments as `Client.executeQuery`.
 
-| Argument        | Type                         | Description                                                                                                                                                                                                                                                             |
-| --------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `client`        | `Client.t`                   | The `urql` client instance.                                                                                                                                                                                                                                             |
-| `request`       | `Types.request`              | The `graphql_ppx` request representing your query. Generated by calling `.make()` on the `graphql_ppx` module. If you're not using `graphql_ppx`, pass a `Js.t` of the following shape: `{. "query": string, "variables": Js.Json.t, "parse": Js.Json.t => 'response }` |
-| `fetchOptions`  | `Fetch.requestInit=?`        | Optional. The fetch options to apply on the outgoing request.                                                                                                                                                                                                           |
-| `requestPolicy` | `Types.requestPolicy=?`      | Optional. The request policy to use to execute the query. Defaults to `"cache-first"`.                                                                                                                                                                                  |
-| `url`           | `string=?`                   | Optional. The GraphQL endpoint to use for the executing operation (if different from the one specified by `Client.make`).                                                                                                                                               |
-| `pollInterval`  | `int=?`                      | Optional. Instructs the client to reexecute the query every `pollInterval` milliseconds.                                                                                                                                                                                |
-| `meta`          | `Types.operationDebugMeta=?` | Optional. Add metadata that is only available in development with devtools.                                                                                                                                                                                             |
-
-`Client.query` returns a `Js.Promise.t` containing the results of executing the query. The result record has a variant type called `response` with constructors for `Data(d)`, `Error(e)`, and `Empty`, in addition to `data` and `error` fields for accessing the raw response values if desired.
-
-| Return                                           | Description                                                                                                                           |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `Js.Promise.t(Client.clientResponse('response))` | A `Js.Promise.t` containing a record of the results of query execution. Use the `response` field on this record for pattern matching. |
+| Return                                       | Description                                                                                                                           |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `Js.Promise.t(Client.clientResponse('data))` | A `Js.Promise.t` containing a record of the results of query execution. Use the `response` field on this record for pattern matching. |
 
 #### Example
 
@@ -193,7 +186,7 @@ module GetAllDogs = [%graphql
 |}
 ];
 
-Client.query(~client, ~request=GetAllDogs.make(), ())
+Client.query(~client, ~query=(module GetAllDogs), ())
   |> Js.Promise.then_(data => {
     switch(Client.(data.response)) {
       | Data(d) => /* Access data returned from executing the request. */
@@ -207,21 +200,25 @@ Client.query(~client, ~request=GetAllDogs.make(), ())
 
 Execute a GraphQL mutation operation.
 
-| Argument        | Type                         | Description                                                                                                                                                                                                                                                                |
-| --------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `client`        | `Client.t`                   | The `urql` client instance.                                                                                                                                                                                                                                                |
-| `request`       | `Types.request`              | The `graphql_ppx` request representing your mutation. Generated by calling `.make()` on the `graphql_ppx` module. If you're not using `graphql_ppx`, pass a `Js.t` of the following shape: `{. "query": string, "variables": Js.Json.t, "parse": Js.Json.t => 'response }` |
-| `fetchOptions`  | `Fetch.requestInit=?`        | Optional. The fetch options to apply on the outgoing request.                                                                                                                                                                                                              |
-| `requestPolicy` | `Types.requestPolicy=?`      | Optional. The request policy to use to execute the query. Defaults to `"cache-first"`.                                                                                                                                                                                     |
-| `url`           | `string=?`                   | Optional. The GraphQL endpoint to use for the executing operation (if different from the one specified by `Client.make`).                                                                                                                                                  |
-| `pollInterval`  | `int=?`                      | Optional. Instructs the client to reexecute the mutation every `pollInterval` milliseconds.                                                                                                                                                                                |
-| `meta`          | `Types.operationDebugMeta=?` | Optional. Add metadata that is only available in development with devtools.                                                                                                                                                                                                |
+| Argument              | Type                          | Description                                                                                                                                             |
+| --------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client`              | `Client.t`                    | The `urql` client instance.                                                                                                                             |
+| `mutation`            | `(module Types.Operation)`    | The `graphql_ppx` module representing your GraphQL operation.                                                                                           |
+| `additionalTypenames` | `array(string)=?`             | Optional. Flag that this operation depends on certain `__typename`s. Used by default in the document cache.                                             |
+| `fetchOptions`        | `Fetch.requestInit=?`         | Optional. The fetch options to apply on the outgoing request.                                                                                           |
+| `requestPolicy`       | `Types.requestPolicy=?`       | Optional. The request policy to use to execute the query. Defaults to `"cache-first"`.                                                                  |
+| `url`                 | `string=?`                    | Optional. The GraphQL endpoint to use for the executing operation (if different from the one specified by `Client.make`).                               |
+| `pollInterval`        | `int=?`                       | Optional. Instructs the client to reexecute the query every `pollInterval` milliseconds.                                                                |
+| `meta`                | `Types.operationDebugMeta=?`  | Optional. Add metadata that is only available in development with devtools.                                                                             |
+| `suspense`            | `bool=?`                      | Optional. A flag activating the experimental React suspense mode, which can be used during server-side rendering to prefetch data. Defaults to `false`. |
+| `preferGetMethod`     | `bool=?`                      | Optional. If `true`, will use the HTTP GET method rather than POST for operations of type `query`. Defaults to `false`.                                 |
+| `variables`           | `Types.Operation.t_variables` | Optional. Variables to pass as part of your GraphQL query. This should be passed as the last positional argument, if needed.                            |
 
-`Client.executeMutation` returns a [`wonka` `source`](https://wonka.kitten.sh/api/sources) containing the results of executing the mutation. The result record has a variant type called `response` with constructors for `Data(d)`, `Error(e)`, and `Empty`, in addition to `data` and `error` fields for accessing the raw response values if desired.
+`Client.executeMutation` returns a [`wonka` `source`](https://wonka.kitten.sh/api/sources) containing the results of executing the mutation. The result record has a variant type called `response` with constructors for `Data(d)`, `PartialData(d, e)`, `Error(e)`, and `Empty`, in addition to `data` and `error` fields for accessing the raw response values if desired.
 
-| Return                                                  | Description                                                                                                                                |
-| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Wonka.Types.sourceT(Client.clientResponse('response))` | A `wonka` `source` containing a record of the results of mutation execution. Use the `response` field on this record for pattern matching. |
+| Return                                              | Description                                                                                                                                |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Wonka.Types.sourceT(Client.clientResponse('data))` | A `wonka` `source` containing a record of the results of mutation execution. Use the `response` field on this record for pattern matching. |
 
 #### Example
 
@@ -242,7 +239,7 @@ module LikeDog = [%graphql
 |}
 ];
 
-Client.executeMutation(~client, ~request=LikeDog.make(~key="VmeRTX7j-", ()), ())
+Client.executeMutation(~client, ~mutation=(module LikeDog), LikeDog.{ key: "VmeRTX7j-" })
   |> Wonka.subscribe((. data) => {
     switch(Client.(data.response)) {
       | Data(d) => /* Access data returned from executing the request. */
@@ -254,23 +251,11 @@ Client.executeMutation(~client, ~request=LikeDog.make(~key="VmeRTX7j-", ()), ())
 
 ### `Client.mutation`
 
-The same as `Client.executeMutation`, but returns a `Js.Promise.t` rather than a `wonka` `source`.
+The same as `Client.executeMutation`, but returns a `Js.Promise.t` rather than a `wonka` `source`. This method accepts all of the same arguments as `Client.executeMutation`.
 
-| Argument        | Type                         | Description                                                                                                                                                                                                                                                             |
-| --------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `client`        | `Client.t`                   | The `urql` client instance.                                                                                                                                                                                                                                             |
-| `request`       | `Types.request`              | The `graphql_ppx` request representing your query. Generated by calling `.make()` on the `graphql_ppx` module. If you're not using `graphql_ppx`, pass a `Js.t` of the following shape: `{. "query": string, "variables": Js.Json.t, "parse": Js.Json.t => 'response }` |
-| `fetchOptions`  | `Fetch.requestInit=?`        | Optional. The fetch options to apply on the outgoing request.                                                                                                                                                                                                           |
-| `requestPolicy` | `Types.requestPolicy=?`      | Optional. The request policy to use to execute the query. Defaults to `"cache-first"`.                                                                                                                                                                                  |
-| `url`           | `string=?`                   | Optional. The GraphQL endpoint to use for the executing operation (if different from the one specified by `Client.make`).                                                                                                                                               |
-| `pollInterval`  | `int=?`                      | Optional. Instructs the client to reexecute the mutation every `pollInterval` milliseconds.                                                                                                                                                                             |
-| `meta`          | `Types.operationDebugMeta=?` | Optional. Add metadata that is only available in development with devtools.                                                                                                                                                                                             |
-
-`Client.mutation` returns a `Js.Promise.t` containing the results of executing the mutation. The result record has a variant type called `response` with constructors for `Data(d)`, `Error(e)`, and `Empty`, in addition to `data` and `error` fields for accessing the raw response values if desired.
-
-| Return                                           | Description                                                                                                                              |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `Js.Promise.t(Client.clientResponse('response))` | A `Js.Promise.t` containing a record of the results of mutation execution. Use the `response` field on this record for pattern matching. |
+| Return                                       | Description                                                                                                                              |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `Js.Promise.t(Client.clientResponse('data))` | A `Js.Promise.t` containing a record of the results of mutation execution. Use the `response` field on this record for pattern matching. |
 
 #### Example
 
@@ -291,9 +276,9 @@ module LikeDog = [%graphql
 |}
 ];
 
-Client.mutation(~client, ~request=LikeDog.make(~key="VmeRTX7j-", ()), ())
+Client.mutation(~client, ~mutation=(module LikeDog), LikeDog.{ key: "VmeRTX7j-" })
   |> Js.Promise.then_(data => {
-    switch(Client.(data.response)) {
+    switch (Client.(data.response)) {
       | Data(d) => /* Access data returned from executing the request. */
       | Error(e) => /* Access any errors returned from executing the request. */
       | Empty => /* Fallback if neither Data nor Error return information. */
@@ -305,15 +290,23 @@ Client.mutation(~client, ~request=LikeDog.make(~key="VmeRTX7j-", ()), ())
 
 Execute a GraphQL subscription operation. If using the `executeSubscription` method, be sure your client is configured with the `subscriptionExchange`.
 
-| Argument        | Type                         | Description                                                                                                                                                                                                                                                                    |
-| --------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `client`        | `Client.t`                   | The `urql` client instance.                                                                                                                                                                                                                                                    |
-| `request`       | `Types.graphqlRequest`       | The `graphql_ppx` request representing your subscription. Generated by calling `.make()` on the `graphql_ppx` module. If you're not using `graphql_ppx`, pass a `Js.t` of the following shape: `{. "query": string, "variables": Js.Json.t, "parse": Js.Json.t => 'response }` |
-| `fetchOptions`  | `Fetch.requestInit=?`        | Optional. The fetch options to apply on the outgoing request.                                                                                                                                                                                                                  |
-| `requestPolicy` | `Types.requestPolicy=?`      | Optional. The request policy to use to execute the query. Defaults to `"cache-first"`.                                                                                                                                                                                         |
-| `url`           | `string=?`                   | Optional. The GraphQL endpoint to use for the executing operation (if different from the one specified by `Client.make`).                                                                                                                                                      |
-| `pollInterval`  | `int=?`                      | Optional. Instructs the client to reexecute the mutation every `pollInterval` milliseconds.                                                                                                                                                                                    |
-| `meta`          | `Types.operationDebugMeta=?` | Optional. Add metadata that is only available in development with devtools.                                                                                                                                                                                                    |
+| Argument              | Type                          | Description                                                                                                                                             |
+| --------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client`              | `Client.t`                    | The `urql` client instance.                                                                                                                             |
+| `subscription`        | `(module Types.Operation)`    | The `graphql_ppx` module representing your GraphQL operation.                                                                                           |
+| `additionalTypenames` | `array(string)=?`             | Optional. Flag that this operation depends on certain `__typename`s. Used by default in the document cache.                                             |
+| `fetchOptions`        | `Fetch.requestInit=?`         | Optional. The fetch options to apply on the outgoing request.                                                                                           |
+| `requestPolicy`       | `Types.requestPolicy=?`       | Optional. The request policy to use to execute the query. Defaults to `"cache-first"`.                                                                  |
+| `url`                 | `string=?`                    | Optional. The GraphQL endpoint to use for the executing operation (if different from the one specified by `Client.make`).                               |
+| `pollInterval`        | `int=?`                       | Optional. Instructs the client to reexecute the query every `pollInterval` milliseconds.                                                                |
+| `meta`                | `Types.operationDebugMeta=?`  | Optional. Add metadata that is only available in development with devtools.                                                                             |
+| `suspense`            | `bool=?`                      | Optional. A flag activating the experimental React suspense mode, which can be used during server-side rendering to prefetch data. Defaults to `false`. |
+| `preferGetMethod`     | `bool=?`                      | Optional. If `true`, will use the HTTP GET method rather than POST for operations of type `query`. Defaults to `false`.                                 |
+| `variables`           | `Types.Operation.t_variables` | Optional. Variables to pass as part of your GraphQL query. This should be passed as the last positional argument, if needed.                            |
+
+| Return                                              | Description                                                                                                                                    |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Wonka.Types.sourceT(Client.clientResponse('data))` | A `wonka` `source` containing a record of the results of subscription execution. Use the `response` field on this record for pattern matching. |
 
 #### Example
 
@@ -331,7 +324,7 @@ module SubscribeMessages = [%graphql
 |}
 ];
 
-Client.executeSubscription(~client, ~request=SubscribeMessages.make(), ())
+Client.executeSubscription(~client, ~subscription=(module SubscribeMessages), ())
   |> Wonka.subscribe((. data) => {
     switch(Client.(data.response)) {
       | Data(d) => /* Access data returned from executing the request. */
@@ -340,3 +333,15 @@ Client.executeSubscription(~client, ~request=SubscribeMessages.make(), ())
     }
   });
 ```
+
+### `Client.subscription`
+
+An alias for `Client.executeSubscription`.
+
+### `Client.readQuery`
+
+Execute a GraphQL query, but immediately unsubscribe from the result. This method is particularly useful for reading directly from the cache without issuing a request to your GraphQL API. This method accepts all of the same arguments as `Client.executeQuery` and `Client.query`.
+
+| Return                                 | Description                                                            |
+| -------------------------------------- | ---------------------------------------------------------------------- |
+| `option(Client.clientResponse('data))` | `Some(response)` if a result was found in the cache, otherwise `None`. |

--- a/examples/1-execute-query-mutation/package.json
+++ b/examples/1-execute-query-mutation/package.json
@@ -15,6 +15,7 @@
     "@reasonml-community/graphql-ppx": "^1.0.1",
     "graphql": "^15.4.0",
     "react": "^16.8.0",
+    "react-dom": "^16.8.0",
     "reason-react": "^0.7.0",
     "reason-urql": "link:../../",
     "urql": "~1.10.0"

--- a/examples/1-execute-query-mutation/src/Previewer.re
+++ b/examples/1-execute-query-mutation/src/Previewer.re
@@ -73,15 +73,14 @@ let make = () => {
 
     Client.executeQuery(
       ~client,
-      ~request=(module GetAllDogs),
-      ~variables=GetAllDogs.makeVariables(),
+      ~query=(module GetAllDogs),
       ~requestPolicy=`CacheAndNetwork,
       (),
     )
     |> Wonka.subscribe((. data) => {
          dispatch(SetQueryFetching(false));
 
-         switch (Client.(data.response)) {
+         switch (Types.(data.response)) {
          | Data(d) =>
            dispatch(SetQuery(d->GetAllDogs.serialize->GetAllDogs.toJson))
          | Error(_e) =>
@@ -96,14 +95,13 @@ let make = () => {
 
     Client.executeMutation(
       ~client,
-      ~request=(module LikeDog),
-      ~variables=LikeDog.makeVariables(~key="VmeRTX7j-", ()),
-      (),
+      ~mutation=(module LikeDog),
+      LikeDog.{key: "VmeRTX7j-"},
     )
     |> Wonka.subscribe((. data) => {
          dispatch(SetMutationFetching(false));
 
-         switch (Client.(data.response)) {
+         switch (Types.(data.response)) {
          | Data(d) =>
            dispatch(SetMutation(d->LikeDog.serialize->LikeDog.toJson))
          | Error(_e) =>

--- a/examples/1-execute-query-mutation/yarn.lock
+++ b/examples/1-execute-query-mutation/yarn.lock
@@ -3074,6 +3074,16 @@ react-dom@>=16.8.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-dom@^16.8.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
+  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
+
 react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"

--- a/examples/4-exchanges/package.json
+++ b/examples/4-exchanges/package.json
@@ -15,6 +15,7 @@
     "@reasonml-community/graphql-ppx": "^1.0.1",
     "graphql": "^15.4.0",
     "react": "^16.8.0",
+    "react-dom": "^16.8.0",
     "reason-react": "^0.7.0",
     "reason-urql": "link:../../",
     "urql": "~1.10.0"

--- a/examples/4-exchanges/public/index.css
+++ b/examples/4-exchanges/public/index.css
@@ -8,7 +8,7 @@
 
 .console__title {
   font-size: 5rem;
-  padding: 1rem;
+  padding: 10rem;
 }
 
 .console__code {

--- a/examples/4-exchanges/src/Console.re
+++ b/examples/4-exchanges/src/Console.re
@@ -31,14 +31,9 @@ let make = (~client) => {
       let mutSub = ref(Wonka_types.{unsubscribe: () => ()});
 
       let subscription =
-        Client.executeQuery(
-          ~client,
-          ~request=(module GetAllDogs),
-          ~variables=GetAllDogs.makeVariables(),
-          (),
-        )
+        Client.executeQuery(~client, ~query=(module GetAllDogs), ())
         |> Wonka.subscribe((. data) =>
-             switch (Client.(data.response)) {
+             switch (Types.(data.response)) {
              | Data(d) =>
                Js_global.setInterval(
                  () => {
@@ -47,10 +42,8 @@ let make = (~client) => {
                    let mutationSubscription =
                      Client.executeMutation(
                        ~client,
-                       ~request=(module LikeDog),
-                       ~variables=
-                         LikeDog.makeVariables(~key=d.dogs[0].key, ()),
-                       (),
+                       ~mutation=(module LikeDog),
+                       LikeDog.{key: d.dogs[0].key},
                      )
                      |> Wonka.subscribe((. response) => Js.log(response));
 

--- a/examples/4-exchanges/yarn.lock
+++ b/examples/4-exchanges/yarn.lock
@@ -3074,6 +3074,16 @@ react-dom@>=16.8.1:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
+react-dom@^16.8.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
+  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
+
 react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
@@ -3281,6 +3291,14 @@ scheduler@^0.13.6:
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
   integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"

--- a/examples/5-subscription/src/app/Circles.re
+++ b/examples/5-subscription/src/app/Circles.re
@@ -19,7 +19,7 @@ let handler = (prevSubscriptions, subscription) => {
 let make = () => {
   let (Hooks.{response}, _) =
     Hooks.useSubscription(
-      ~query=(module SubscribeRandomInt),
+      ~subscription=(module SubscribeRandomInt),
       ~handler=Handler(handler),
       (),
     );

--- a/examples/5-subscription/src/app/Squares.re
+++ b/examples/5-subscription/src/app/Squares.re
@@ -19,7 +19,7 @@ let handler = (prevSubscriptions, subscription) => {
 let make = () => {
   let ({Hooks.response}, _) =
     Hooks.useSubscription(
-      ~query=(module SubscribeRandomFloat),
+      ~subscription=(module SubscribeRandomFloat),
       ~handler=Handler(handler),
       (),
     );

--- a/src/Client.re
+++ b/src/Client.re
@@ -197,11 +197,10 @@ let executeQuery:
   type variables variablesJs data.
     (
       ~client: t,
-      ~request: (module Types.Operation with
-                   type t_variables = variables and
-                   type Raw.t_variables = variablesJs and
-                   type t = data),
-      ~variables: variables,
+      ~query: (module Types.Operation with
+                 type t_variables = variables and
+                 type Raw.t_variables = variablesJs and
+                 type t = data),
       ~additionalTypenames: array(string)=?,
       ~fetchOptions: Fetch.requestInit=?,
       ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
@@ -211,13 +210,12 @@ let executeQuery:
       ~meta: Types.operationDebugMeta=?,
       ~suspense: bool=?,
       ~preferGetMethod: bool=?,
-      unit
+      variables
     ) =>
     Wonka.Types.sourceT(Types.operationResult(data)) =
   (
     ~client,
-    ~request as (module Request),
-    ~variables: variables,
+    ~query as (module Query),
     ~additionalTypenames=?,
     ~fetchOptions=?,
     ~fetch=?,
@@ -227,13 +225,12 @@ let executeQuery:
     ~meta=?,
     ~suspense=?,
     ~preferGetMethod=?,
-    (),
+    variables,
   ) => {
     let req =
       Utils.createRequest(
-        ~query=Request.query,
-        ~variables=
-          variables->Request.serializeVariables->Request.variablesToJson,
+        ~query=Query.query,
+        ~variables=variables->Query.serializeVariables->Query.variablesToJson,
         (),
       );
 
@@ -254,7 +251,7 @@ let executeQuery:
 
     executeQueryJs(~client, ~query=req, ~opts=optsJs, ())
     |> Wonka.map((. response) =>
-         Types.operationResultToReason(~response, ~parse=Request.parse)
+         Types.operationResultToReason(~response, ~parse=Query.parse)
        );
   };
 
@@ -273,11 +270,10 @@ let executeMutation:
   type variables variablesJs data.
     (
       ~client: t,
-      ~request: (module Types.Operation with
-                   type t_variables = variables and
-                   type Raw.t_variables = variablesJs and
-                   type t = data),
-      ~variables: variables,
+      ~mutation: (module Types.Operation with
+                    type t_variables = variables and
+                    type Raw.t_variables = variablesJs and
+                    type t = data),
       ~additionalTypenames: array(string)=?,
       ~fetchOptions: Fetch.requestInit=?,
       ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
@@ -287,13 +283,12 @@ let executeMutation:
       ~meta: Types.operationDebugMeta=?,
       ~suspense: bool=?,
       ~preferGetMethod: bool=?,
-      unit
+      variables
     ) =>
     Wonka.Types.sourceT(Types.operationResult(data)) =
   (
     ~client: t,
-    ~request as (module Request),
-    ~variables,
+    ~mutation as (module Mutation),
     ~additionalTypenames=?,
     ~fetchOptions=?,
     ~fetch=?,
@@ -303,16 +298,15 @@ let executeMutation:
     ~meta=?,
     ~suspense=?,
     ~preferGetMethod=?,
-    (),
+    variables,
   ) => {
     let req =
       Utils.createRequest(
-        ~query=Request.query,
+        ~query=Mutation.query,
         ~variables=
-          variables->Request.serializeVariables->Request.variablesToJson,
+          variables->Mutation.serializeVariables->Mutation.variablesToJson,
         (),
       );
-    let parse = Request.parse;
     let optsJs =
       Types.partialOperationContext(
         ~additionalTypenames?,
@@ -330,7 +324,7 @@ let executeMutation:
 
     executeMutationJs(~client, ~mutation=req, ~opts=optsJs, ())
     |> Wonka.map((. response) =>
-         Types.operationResultToReason(~response, ~parse)
+         Types.operationResultToReason(~response, ~parse=Mutation.parse)
        );
   };
 
@@ -349,11 +343,10 @@ let executeSubscription:
   type variables variablesJs data.
     (
       ~client: t,
-      ~request: (module Types.Operation with
-                   type t_variables = variables and
-                   type Raw.t_variables = variablesJs and
-                   type t = data),
-      ~variables: variables,
+      ~subscription: (module Types.Operation with
+                        type t_variables = variables and
+                        type Raw.t_variables = variablesJs and
+                        type t = data),
       ~additionalTypenames: array(string)=?,
       ~fetchOptions: Fetch.requestInit=?,
       ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
@@ -363,13 +356,12 @@ let executeSubscription:
       ~meta: Types.operationDebugMeta=?,
       ~suspense: bool=?,
       ~preferGetMethod: bool=?,
-      unit
+      variables
     ) =>
     Wonka.Types.sourceT(Types.operationResult(data)) =
   (
     ~client: t,
-    ~request as (module Request),
-    ~variables,
+    ~subscription as (module Subscription),
     ~additionalTypenames=?,
     ~fetchOptions=?,
     ~fetch=?,
@@ -379,16 +371,17 @@ let executeSubscription:
     ~meta=?,
     ~suspense=?,
     ~preferGetMethod=?,
-    (),
+    variables,
   ) => {
     let req =
       Utils.createRequest(
-        ~query=Request.query,
+        ~query=Subscription.query,
         ~variables=
-          variables->Request.serializeVariables->Request.variablesToJson,
+          variables
+          ->Subscription.serializeVariables
+          ->Subscription.variablesToJson,
         (),
       );
-    let parse = Request.parse;
     let optsJs =
       Types.partialOperationContext(
         ~additionalTypenames?,
@@ -406,15 +399,14 @@ let executeSubscription:
 
     executeSubscriptionJs(~client, ~subscription=req, ~opts=optsJs, ())
     |> Wonka.map((. response) =>
-         Types.operationResultToReason(~response, ~parse)
+         Types.operationResultToReason(~response, ~parse=Subscription.parse)
        );
   };
 
 let query =
     (
       ~client,
-      ~request,
-      ~variables,
+      ~query,
       ~additionalTypenames=?,
       ~fetchOptions=?,
       ~fetch=?,
@@ -424,12 +416,11 @@ let query =
       ~meta=?,
       ~suspense=?,
       ~preferGetMethod=?,
-      (),
+      variables,
     ) => {
   executeQuery(
     ~client,
-    ~request,
-    ~variables,
+    ~query,
     ~additionalTypenames?,
     ~fetchOptions?,
     ~fetch?,
@@ -439,7 +430,7 @@ let query =
     ~meta?,
     ~suspense?,
     ~preferGetMethod?,
-    (),
+    variables,
   )
   |> Wonka.take(1)
   |> Wonka.toPromise;
@@ -448,8 +439,7 @@ let query =
 let mutation =
     (
       ~client,
-      ~request,
-      ~variables,
+      ~mutation,
       ~additionalTypenames=?,
       ~fetchOptions=?,
       ~fetch=?,
@@ -459,12 +449,11 @@ let mutation =
       ~meta=?,
       ~suspense=?,
       ~preferGetMethod=?,
-      (),
+      variables,
     ) => {
   executeMutation(
     ~client,
-    ~request,
-    ~variables,
+    ~mutation,
     ~additionalTypenames?,
     ~fetchOptions?,
     ~fetch?,
@@ -474,7 +463,7 @@ let mutation =
     ~meta?,
     ~suspense?,
     ~preferGetMethod?,
-    (),
+    variables,
   )
   |> Wonka.take(1)
   |> Wonka.toPromise;
@@ -485,8 +474,7 @@ let subscription = executeSubscription;
 let readQuery =
     (
       ~client,
-      ~request,
-      ~variables,
+      ~query,
       ~additionalTypenames=?,
       ~fetchOptions=?,
       ~fetch=?,
@@ -496,13 +484,12 @@ let readQuery =
       ~meta=?,
       ~suspense=?,
       ~preferGetMethod=?,
-      (),
+      variables,
     ) => {
   let result = ref(None);
   executeQuery(
     ~client,
-    ~request,
-    ~variables,
+    ~query,
     ~additionalTypenames?,
     ~fetchOptions?,
     ~fetch?,
@@ -512,7 +499,7 @@ let readQuery =
     ~meta?,
     ~suspense?,
     ~preferGetMethod?,
-    (),
+    variables,
   )
   |> Wonka.subscribe((. data) => {result := Some(data)})
   |> (subscription => subscription.unsubscribe());

--- a/src/Client.rei
+++ b/src/Client.rei
@@ -128,11 +128,10 @@ let make:
 let executeQuery:
   (
     ~client: t,
-    ~request: (module Types.Operation with
-                 type t = 'data and
-                 type t_variables = 'variables and
-                 type Raw.t_variables = 'variablesJs),
-    ~variables: 'variables,
+    ~query: (module Types.Operation with
+               type t = 'data and
+               type t_variables = 'variables and
+               type Raw.t_variables = 'variablesJs),
     ~additionalTypenames: array(string)=?,
     ~fetchOptions: Fetch.requestInit=?,
     ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
@@ -142,18 +141,17 @@ let executeQuery:
     ~meta: Types.operationDebugMeta=?,
     ~suspense: bool=?,
     ~preferGetMethod: bool=?,
-    unit
+    'variables
   ) =>
   Wonka.Types.sourceT(Types.operationResult('data));
 
 let executeMutation:
   (
     ~client: t,
-    ~request: (module Types.Operation with
-                 type t = 'data and
-                 type t_variables = 'variables and
-                 type Raw.t_variables = 'variablesJs),
-    ~variables: 'variables,
+    ~mutation: (module Types.Operation with
+                  type t = 'data and
+                  type t_variables = 'variables and
+                  type Raw.t_variables = 'variablesJs),
     ~additionalTypenames: array(string)=?,
     ~fetchOptions: Fetch.requestInit=?,
     ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
@@ -163,18 +161,17 @@ let executeMutation:
     ~meta: Types.operationDebugMeta=?,
     ~suspense: bool=?,
     ~preferGetMethod: bool=?,
-    unit
+    'variables
   ) =>
   Wonka.Types.sourceT(Types.operationResult('data));
 
 let executeSubscription:
   (
     ~client: t,
-    ~request: (module Types.Operation with
-                 type t = 'data and
-                 type t_variables = 'variables and
-                 type Raw.t_variables = 'variablesJs),
-    ~variables: 'variables,
+    ~subscription: (module Types.Operation with
+                      type t = 'data and
+                      type t_variables = 'variables and
+                      type Raw.t_variables = 'variablesJs),
     ~additionalTypenames: array(string)=?,
     ~fetchOptions: Fetch.requestInit=?,
     ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
@@ -184,18 +181,17 @@ let executeSubscription:
     ~meta: Types.operationDebugMeta=?,
     ~suspense: bool=?,
     ~preferGetMethod: bool=?,
-    unit
+    'variables
   ) =>
   Wonka.Types.sourceT(Types.operationResult('data));
 
 let query:
   (
     ~client: t,
-    ~request: (module Types.Operation with
-                 type t = 'data and
-                 type t_variables = 'variables and
-                 type Raw.t_variables = 'variablesJs),
-    ~variables: 'variables,
+    ~query: (module Types.Operation with
+               type t = 'data and
+               type t_variables = 'variables and
+               type Raw.t_variables = 'variablesJs),
     ~additionalTypenames: array(string)=?,
     ~fetchOptions: Fetch.requestInit=?,
     ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
@@ -205,18 +201,17 @@ let query:
     ~meta: Types.operationDebugMeta=?,
     ~suspense: bool=?,
     ~preferGetMethod: bool=?,
-    unit
+    'variables
   ) =>
   Js.Promise.t(Types.operationResult('data));
 
 let mutation:
   (
     ~client: t,
-    ~request: (module Types.Operation with
-                 type t = 'data and
-                 type t_variables = 'variables and
-                 type Raw.t_variables = 'variablesJs),
-    ~variables: 'variables,
+    ~mutation: (module Types.Operation with
+                  type t = 'data and
+                  type t_variables = 'variables and
+                  type Raw.t_variables = 'variablesJs),
     ~additionalTypenames: array(string)=?,
     ~fetchOptions: Fetch.requestInit=?,
     ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
@@ -226,18 +221,17 @@ let mutation:
     ~meta: Types.operationDebugMeta=?,
     ~suspense: bool=?,
     ~preferGetMethod: bool=?,
-    unit
+    'variables
   ) =>
   Js.Promise.t(Types.operationResult('data));
 
 let subscription:
   (
     ~client: t,
-    ~request: (module Types.Operation with
-                 type t = 'data and
-                 type t_variables = 'variables and
-                 type Raw.t_variables = 'variablesJs),
-    ~variables: 'variables,
+    ~subscription: (module Types.Operation with
+                      type t = 'data and
+                      type t_variables = 'variables and
+                      type Raw.t_variables = 'variablesJs),
     ~additionalTypenames: array(string)=?,
     ~fetchOptions: Fetch.requestInit=?,
     ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
@@ -247,18 +241,17 @@ let subscription:
     ~meta: Types.operationDebugMeta=?,
     ~suspense: bool=?,
     ~preferGetMethod: bool=?,
-    unit
+    'variables
   ) =>
   Wonka.Types.sourceT(Types.operationResult('data));
 
 let readQuery:
   (
     ~client: t,
-    ~request: (module Types.Operation with
-                 type t = 'data and
-                 type t_variables = 'variables and
-                 type Raw.t_variables = 'variablesJs),
-    ~variables: 'variables,
+    ~query: (module Types.Operation with
+               type t = 'data and
+               type t_variables = 'variables and
+               type Raw.t_variables = 'variablesJs),
     ~additionalTypenames: array(string)=?,
     ~fetchOptions: Fetch.requestInit=?,
     ~fetch: (string, Fetch.requestInit) => Js.Promise.t(Fetch.response)=?,
@@ -268,6 +261,6 @@ let readQuery:
     ~meta: Types.operationDebugMeta=?,
     ~suspense: bool=?,
     ~preferGetMethod: bool=?,
-    unit
+    'variables
   ) =>
   option(Types.operationResult('data));

--- a/src/hooks/Hooks.re
+++ b/src/hooks/Hooks.re
@@ -4,12 +4,12 @@ include UseMutation;
 include UseSubscription;
 
 type hookResponse('ret) =
-  Types.hookResponse('ret) = {
+  Types.Hooks.hookResponse('ret) = {
     operation: Types.operation,
     fetching: bool,
     data: option('ret),
     error: option(CombinedError.t),
-    response: Types.response('ret),
+    response: Types.Hooks.response('ret),
     extensions: option(Js.Json.t),
     stale: bool,
   };

--- a/src/hooks/UseMutation.re
+++ b/src/hooks/UseMutation.re
@@ -18,12 +18,12 @@ type executeMutation('variables, 'data) =
   Js.Promise.t(Types.operationResult('data));
 
 type useMutationResponseJs('dataJs) = (
-  Types.hookResponseJs('dataJs),
+  Types.Hooks.hookResponseJs('dataJs),
   executeMutationJs('dataJs),
 );
 
 type useMutationResponse('variables, 'data) = (
-  Types.hookResponse('data),
+  Types.Hooks.hookResponse('data),
   executeMutation('variables, 'data),
 );
 
@@ -49,7 +49,7 @@ let useMutation:
 
     let state =
       React.useMemo2(
-        () => Types.urqlResponseToReason(~response=stateJs, ~parse),
+        () => Types.Hooks.hookResponseToReason(~response=stateJs, ~parse),
         (stateJs, parse),
       );
 

--- a/src/hooks/UseMutation.rei
+++ b/src/hooks/UseMutation.rei
@@ -14,7 +14,7 @@ type executeMutation('variables, 'data) =
   Js.Promise.t(Types.operationResult('data));
 
 type useMutationResponse('variables, 'data) = (
-  Types.hookResponse('data),
+  Types.Hooks.hookResponse('data),
   executeMutation('variables, 'data),
 );
 

--- a/src/hooks/UseQuery.re
+++ b/src/hooks/UseQuery.re
@@ -10,7 +10,7 @@ type useQueryArgsJs = {
 type executeQueryJs = Types.partialOperationContext => unit;
 
 type useQueryResponseJs('dataJs) = (
-  Types.hookResponseJs('dataJs),
+  Types.Hooks.hookResponseJs('dataJs),
   executeQueryJs,
 );
 
@@ -29,7 +29,10 @@ type executeQuery =
   ) =>
   unit;
 
-type useQueryResponse('data) = (Types.hookResponse('data), executeQuery);
+type useQueryResponse('data) = (
+  Types.Hooks.hookResponse('data),
+  executeQuery,
+);
 
 [@bs.module "urql"]
 external useQueryJs: useQueryArgsJs => useQueryResponseJs('dataJs) =
@@ -129,7 +132,7 @@ let useQuery:
 
     let state =
       React.useMemo2(
-        () => Types.urqlResponseToReason(~response=stateJs, ~parse),
+        () => Types.Hooks.hookResponseToReason(~response=stateJs, ~parse),
         (stateJs, parse),
       );
 

--- a/src/hooks/UseQuery.rei
+++ b/src/hooks/UseQuery.rei
@@ -13,7 +13,10 @@ type executeQuery =
   ) =>
   unit;
 
-type useQueryResponse('data) = (Types.hookResponse('data), executeQuery);
+type useQueryResponse('data) = (
+  Types.Hooks.hookResponse('data),
+  executeQuery,
+);
 
 let useQuery:
   (

--- a/src/hooks/UseSubscription.re
+++ b/src/hooks/UseSubscription.re
@@ -20,7 +20,7 @@ type executeSubscriptionJs = Types.partialOperationContext => unit;
 [@bs.module "urql"]
 external useSubscriptionJs:
   (useSubscriptionArgs, option((option('acc), 'dataJs) => 'acc)) =>
-  (Types.hookResponseJs('ret), executeSubscriptionJs) =
+  (Types.Hooks.hookResponseJs('ret), executeSubscriptionJs) =
   "useSubscription";
 
 type executeSubscription =
@@ -39,12 +39,13 @@ type executeSubscription =
   unit;
 
 type useSubscriptionResponse('response) = (
-  Types.hookResponse('response),
+  Types.Hooks.hookResponse('response),
   executeSubscription,
 );
 
-let subscriptionResponseToReason = (response: Types.hookResponseJs('ret)) => {
-  let Types.{operation, fetching, extensions, stale} = response;
+let subscriptionResponseToReason =
+    (response: Types.Hooks.hookResponseJs('ret)) => {
+  let Types.Hooks.{operation, fetching, extensions, stale} = response;
 
   let data = response.data->Js.Nullable.toOption;
   let error =
@@ -52,14 +53,14 @@ let subscriptionResponseToReason = (response: Types.hookResponseJs('ret)) => {
 
   let response =
     switch (fetching, data, error) {
-    | (true, None, None) => Types.Fetching
+    | (true, None, None) => Types.Hooks.Fetching
     | (_, Some(d), None) => Data(d)
     | (_, Some(d), Some(e)) => PartialData(d, e.graphQLErrors)
     | (_, None, Some(e)) => Error(e)
     | (false, None, None) => Empty
     };
 
-  Types.{operation, fetching, data, error, response, extensions, stale};
+  Types.Hooks.{operation, fetching, data, error, response, extensions, stale};
 };
 
 // reason-react does not provide a binding of sufficient arity for our memoization needs

--- a/src/hooks/UseSubscription.rei
+++ b/src/hooks/UseSubscription.rei
@@ -19,7 +19,7 @@ type executeSubscription =
   unit;
 
 type useSubscriptionResponse('data) = (
-  Types.hookResponse('data),
+  Types.Hooks.hookResponse('data),
   executeSubscription,
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3596,16 +3596,6 @@ react-dom@>=16.8.1:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
-react-dom@^16.8.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
-
 react-is@^16.12.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -3896,14 +3886,6 @@ scheduler@^0.13.6:
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"
   integrity sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
This PR does a few things:

1. Updates our `Client` APIs:
  - The `~request` labeled argument is renamed to `~query`, `~mutation`, or `~subscription` depending on the method in use.
  - `variables` are passed as records in the last position, if required. If the query, mutation, or subscription uses no variables, `unit` is passed in the last position.
2. Updates our documentation to reflect the `urql` `peerDependency` introduced in #224 
3. Updates our `Client` documentation to match the latest API changes.
4. Updates our binding to rename `operationName` to `kind` per [this PR](https://github.com/FormidableLabs/urql/pull/1045) in `urql` upstream.

Alongside #225 we're getting _very close_ to a usable `v3`! Moving slowly here but hoping to keep plugging away at everything while I also balance grad school apps this weekend 🤦 