### PR TITLE
Use a record to bind CombinedError. Prepare for ReScript migration.

### DIFF
--- a/__tests__/Types_test.re
+++ b/__tests__/Types_test.re
@@ -79,19 +79,14 @@ describe("Types", () => {
             extensions: None,
           };
 
-        let errorJs = {
-          "message": "Error returned by GraphQL API",
-          "graphQLErrors": [|graphQLError|],
-          "networkError": Js.Nullable.null,
-          "response": Js.Nullable.null,
-        };
-
         let error =
           CombinedError.{
+            name: "CombinedError",
             message: "Error returned by GraphQL API",
             graphQLErrors: [|graphQLError|],
             networkError: None,
             response: None,
+            toString: () => "Error returned by GraphQL API",
           };
 
         let response =
@@ -99,7 +94,7 @@ describe("Types", () => {
             operation: mockOperation,
             fetching: false,
             data: Js.Nullable.return(Js.Json.string("Hello")),
-            error: Some(errorJs),
+            error: Some(error),
             extensions: None,
             stale: false,
           };
@@ -131,19 +126,14 @@ describe("Types", () => {
           extensions: None,
         };
 
-      let errorJs = {
-        "message": "Error returned by GraphQL API",
-        "graphQLErrors": [|graphQLError|],
-        "networkError": Js.Nullable.null,
-        "response": Js.Nullable.null,
-      };
-
       let error =
         CombinedError.{
+          name: "CombinedError",
           message: "Error returned by GraphQL API",
           graphQLErrors: [|graphQLError|],
           networkError: None,
           response: None,
+          toString: () => "Error returned by GraphQL API",
         };
 
       let response =
@@ -151,7 +141,7 @@ describe("Types", () => {
           operation: mockOperation,
           fetching: false,
           data: Js.Nullable.undefined,
-          error: Some(errorJs),
+          error: Some(error),
           extensions: None,
           stale: false,
         };

--- a/src/CombinedError.re
+++ b/src/CombinedError.re
@@ -1,29 +1,8 @@
-class type _combinedError =
-  [@bs]
-  {
-    pub networkError: Js.Nullable.t(Js.Exn.t);
-    pub graphQLErrors: array(GraphQLError.t);
-    pub response: Js.Nullable.t(Fetch.response);
-    pub message: string;
-  };
-
-type combinedErrorJs = Js.t(_combinedError);
-[@bs.module "urql"] external combinedError: combinedErrorJs = "CombinedError";
-
-type combinedError = {
-  networkError: option(Js.Exn.t),
-  graphQLErrors: array(GraphQLError.t),
-  response: option(Fetch.response),
+type t = {
+  name: string,
   message: string,
+  graphQLErrors: array(GraphQLError.t),
+  networkError: option(Js.Exn.t),
+  response: option(Fetch.response),
+  toString: unit => string,
 };
-
-let combinedErrorToRecord = (err: combinedErrorJs): combinedError => {
-  {
-    networkError: err##networkError->Js.Nullable.toOption,
-    graphQLErrors: err##graphQLErrors,
-    response: err##response->Js.Nullable.toOption,
-    message: err##message,
-  };
-};
-
-type t = combinedError;

--- a/src/CombinedError.rei
+++ b/src/CombinedError.rei
@@ -1,22 +1,8 @@
-class type _combinedError =
-  [@bs]
-  {
-    pub networkError: Js.Nullable.t(Js.Exn.t);
-    pub graphQLErrors: array(GraphQLError.t);
-    pub response: Js.Nullable.t(Fetch.response);
-    pub message: string;
-  };
-
-type combinedErrorJs = Js.t(_combinedError);
-[@bs.module "urql"] external combinedError: combinedErrorJs = "CombinedError";
-
-type combinedError = {
-  networkError: option(Js.Exn.t),
-  graphQLErrors: array(GraphQLError.t),
-  response: option(Fetch.response),
+type t = {
+  name: string,
   message: string,
+  graphQLErrors: array(GraphQLError.t),
+  networkError: option(Js.Exn.t),
+  response: option(Fetch.response),
+  toString: unit => string,
 };
-
-let combinedErrorToRecord: combinedErrorJs => combinedError;
-
-type t = combinedError;

--- a/src/Types.re
+++ b/src/Types.re
@@ -81,7 +81,7 @@ type operation = {
 type operationResultJs('dataJs) = {
   operation,
   data: Js.Nullable.t('dataJs),
-  error: option(CombinedError.combinedErrorJs),
+  error: option(CombinedError.t),
   extensions: option(Js.Dict.t(string)),
   stale: option(bool),
 };
@@ -102,10 +102,8 @@ type operationResult('data) = {
 
 let operationResultToReason =
     (~response: operationResultJs('dataJs), ~parse: 'dataJs => 'data) => {
-  let {extensions, stale}: operationResultJs('dataJs) = response;
+  let {error, extensions, stale}: operationResultJs('dataJs) = response;
   let data = response.data->Js.Nullable.toOption->Belt.Option.map(parse);
-  let error =
-    response.error->Belt.Option.map(CombinedError.combinedErrorToRecord);
 
   let response =
     switch (data, error) {
@@ -163,7 +161,7 @@ module Hooks = {
     operation,
     fetching: bool,
     data: Js.Nullable.t('dataJs),
-    error: option(CombinedError.combinedErrorJs),
+    error: option(CombinedError.t),
     extensions: option(Js.Json.t),
     stale: bool,
   };
@@ -177,11 +175,9 @@ module Hooks = {
       (~response: hookResponseJs(dataJs), ~parse: dataJs => data) =>
       hookResponse(data) =
     (~response, ~parse) => {
-      let {operation, fetching, extensions, stale} = response;
+      let {operation, fetching, error, extensions, stale} = response;
 
       let data = response.data->Js.Nullable.toOption->Belt.Option.map(parse);
-      let error =
-        response.error->Belt.Option.map(CombinedError.combinedErrorToRecord);
 
       let response =
         switch (fetching, data, error) {

--- a/src/Types.rei
+++ b/src/Types.rei
@@ -71,7 +71,7 @@ type operation = {
 type operationResultJs('dataJs) = {
   operation,
   data: Js.Nullable.t('dataJs),
-  error: option(CombinedError.combinedErrorJs),
+  error: option(CombinedError.t),
   extensions: option(Js.Dict.t(string)),
   stale: option(bool),
 };
@@ -140,7 +140,7 @@ module Hooks: {
     operation,
     fetching: bool,
     data: Js.Nullable.t('dataJs),
-    error: option(CombinedError.combinedErrorJs),
+    error: option(CombinedError.t),
     extensions: option(Js.Json.t),
     stale: bool,
   };

--- a/src/hooks/UseSubscription.re
+++ b/src/hooks/UseSubscription.re
@@ -45,11 +45,9 @@ type useSubscriptionResponse('response) = (
 
 let subscriptionResponseToReason =
     (response: Types.Hooks.hookResponseJs('ret)) => {
-  let Types.Hooks.{operation, fetching, extensions, stale} = response;
+  let Types.Hooks.{operation, fetching, error, extensions, stale} = response;
 
   let data = response.data->Js.Nullable.toOption;
-  let error =
-    response.error->Belt.Option.map(CombinedError.combinedErrorToRecord);
 
   let response =
     switch (fetching, data, error) {


### PR DESCRIPTION
With ReScript / `bs-platform` > @8, the syntax for binding JS classes to OCaml classes is no longer supported. In many ways this is a good thing — the old syntax was a bit cumbersome and circuitous. However, we still had our `CombinedError` binding using that syntax, which was always more trouble than it was worth. By the time we receive `CombinedError`, it is an _instance_ not the class itself. Therefore, we can treat it (for our purposes) more or less like a JS object. We can bind this with a record in Reason ✅ 

We also don't need to do any `Js.Nullable` conversion here from what I can tell. Based on [the types of instance properties on `CombinedError`](https://github.com/FormidableLabs/urql/blob/main/packages/core/src/utils/error.ts#L41-L45) we would get `undefined` rather than `null` in all cases for optional properties. These can be safely compiled using `option` in Reason. @kitten let me know if that's not the case and I'll add the appropriate `Js.Nullable` wrapper.