### PR TITLE
feat(exchanges): add binding for @urql/exchange-request-policy

### DIFF
--- a/__tests__/Client_test.res
+++ b/__tests__/Client_test.res
@@ -241,5 +241,34 @@ describe("Client", () => {
         })
       })
     })
+
+    describe("requestPolicyExchange", () => {
+      it("should return None for all requestPolicyExchange options if unspecified", () => {
+        let requestPolicyExchangeOptions = Client.Exchanges.makeRequestPolicyExchangeOptions()
+
+        open Expect
+        expect(requestPolicyExchangeOptions) |> toEqual({
+          Client.Exchanges.shouldUpgrade: None,
+          ttl: None,
+        })
+      })
+
+      it("should apply any specified options to the requestPolicyExchange", () => {
+        let shouldUpgrade = (operation: Types.operation) =>
+          operation.context.requestPolicy !== #CacheOnly
+
+        let requestPolicyExchangeOptions = Client.Exchanges.makeRequestPolicyExchangeOptions(
+          ~shouldUpgrade,
+          ~ttl=2000,
+          (),
+        )
+
+        open Expect
+        expect(requestPolicyExchangeOptions) |> toEqual({
+          Client.Exchanges.shouldUpgrade: Some(shouldUpgrade),
+          ttl: Some(2000),
+        })
+      })
+    })
   })
 })

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -237,6 +237,47 @@ let client = Client.make(
 
 Read more on the `retryExchange` [here](https://formidable.com/open-source/urql/docs/advanced/retry-operations/).
 
+### `requestPolicyExchange`
+
+The `requestPolicyExchange` allows `reason-urql` to automatically upgrade an operation's `requestPolicy` on a time-to-live basis. When the specified TTL has elapsed, `reason-urql` will either:
+
+- Upgrade the `requestPolicy` of the operation to `cache-and-network` if no `shouldUpgrade` callback is specified, or:
+- Run the `shouldUpgrade` function to determine whether or not to upgrade the specific operation.
+
+To use the `requestPolicyExchange`, add the package to your dependencies:
+
+```sh
+yarn add @urql/exchange-request-policy
+```
+
+Then, add the exchange to your array of `exchanges`, specifying the options you want to configure:
+
+```rescript
+open ReasonUrql
+
+let shouldUpgrade = (operation: Types.operation) =>
+  operation.context.requestPolicy !== #CacheOnly
+
+let requestPolicyExchangeOptions = Client.Exchanges.makeRequestPolicyExchangeOptions(
+  ~shouldUpgrade,
+  ~ttl=2000,
+  (),
+)
+
+let client = Client.make(
+  ~url="http://localhost:3000",
+  ~exchanges=[
+    Client.Exchanges.dedupExchange,
+    Client.Exchanges.cacheExchange,
+    Client.Exchanges.requestPolicyExchange(requestPolicyExchangeOptions),
+    Client.Exchanges.fetchExchange
+  ],
+  ()
+)
+```
+
+Read more about the `requestPolicyExchange` [here](https://github.com/FormidableLabs/urql/tree/main/exchanges/request-policy).
+
 ## Custom Exchanges
 
 `reason-urql` also allows you to write your own exchanges to modify outgoing GraphQL requests and incoming responses. To read up on the basics of exchanges, check out the excellent [`urql` documentation](https://formidable.com/open-source/urql/docs/concepts/exchanges/).

--- a/src/Client.res
+++ b/src/Client.res
@@ -100,6 +100,19 @@ module Exchanges = {
   @module("@urql/exchange-retry")
   external retryExchange: retryExchangeOptions => t = "retryExchange"
 
+  type requestPolicyExchangeOptions = {
+    shouldUpgrade: option<Types.operation => bool>,
+    ttl: option<int>,
+  }
+
+  let makeRequestPolicyExchangeOptions = (~shouldUpgrade=?, ~ttl=?, ()) => {
+    shouldUpgrade: shouldUpgrade,
+    ttl: ttl,
+  }
+
+  @module("@urql/exchange-request-policy")
+  external requestPolicyExchange: requestPolicyExchangeOptions => t = "requestPolicyExchange"
+
   /* Specific types for the subscriptionExchange. */
   type observerLike<'value> = {
     next: 'value => unit,

--- a/src/Client.resi
+++ b/src/Client.resi
@@ -76,6 +76,20 @@ module Exchanges: {
   @module("@urql/exchange-retry")
   external retryExchange: retryExchangeOptions => t = "retryExchange"
 
+  type requestPolicyExchangeOptions = {
+    shouldUpgrade: option<Types.operation => bool>,
+    ttl: option<int>,
+  }
+
+  let makeRequestPolicyExchangeOptions: (
+    ~shouldUpgrade: Types.operation => bool=?,
+    ~ttl: int=?,
+    unit,
+  ) => requestPolicyExchangeOptions
+
+  @module("@urql/exchange-request-policy")
+  external requestPolicyExchange: requestPolicyExchangeOptions => t = "requestPolicyExchange"
+
   /* Specific types for the subscriptionExchange. */
   type observerLike<'value> = {
     next: 'value => unit,


### PR DESCRIPTION
This PR adds a binding for [`@urql/exchange-request-policy`](https://github.com/FormidableLabs/urql/tree/main/exchanges/request-policy). This was a relatively low cost effort to bind, so I thought it made sense to lump it in with the `retryExchange` before 3.3.0 goes out.

Similar to the binding for `@urql/exchange-retry`, our binding here exposes a `make` function to turn optional parameters into a typed Reason record. This function is called  `makeRequestPolicyExchangeOptions` to keep the nomenclature consistent. An example of the new API in action:

```rescript
open ReasonUrql

let shouldUpgrade = (operation: Types.operation) =>
  operation.context.requestPolicy !== #CacheOnly

let requestPolicyExchangeOptions = Client.Exchanges.makeRequestPolicyExchangeOptions(
  ~shouldUpgrade,
  ~ttl=2000,
  (),
)

let client = Client.make(
  ~url="http://localhost:3000",
  ~exchanges=[
    Client.Exchanges.dedupExchange,
    Client.Exchanges.cacheExchange,
    Client.Exchanges.requestPolicyExchange(requestPolicyExchangeOptions),
    Client.Exchanges.fetchExchange
  ],
  ()
)
```

Fairly straightforward from what I can tell, but would appreciate any feedback all the same!