### PR TITLE
Add rescript keyword to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "keywords": [
     "reason",
     "reasonml",
+    "rescript",
     "bucklescript",
     "graphql",
     "urql"


### PR DESCRIPTION
Since this package is compatible with ReScript it makes sense to 
add the `rescript` keyword to aid in discoverability and cause the 
package to be picked up by [the package overview on rescript-lang.org](https://rescript-lang.org/packages).