### PR TITLE
feat: add bindings for @urql/exchange-persisted-fetch and @urql/exchange-refocus

### DIFF
--- a/__tests__/Client_test.res
+++ b/__tests__/Client_test.res
@@ -210,34 +210,30 @@ describe("Client", () => {
     }))
 
   describe("Ecosystem exchanges", () => {
-    describe("retryExchange", () => {
-      it("should apply the default retryExchange options from urql if none are applied", () => {
-        let retryExchangeOptions = Client.Exchanges.makeRetryExchangeOptions()
+    describe("persistedFetchExchange", () => {
+      it("should return None for all persistedFetchExchange options if unspecified", () => {
+        let persistedFetchExchangeOptions = Client.Exchanges.makePersistedFetchExchangeOptions()
 
         open Expect
-        expect(retryExchangeOptions) |> toEqual({
-          Client.Exchanges.initialDelayMs: None,
-          maxDelayMs: None,
-          maxNumberAttempts: None,
-          randomDelay: None,
-          retryIf: None,
+        expect(persistedFetchExchangeOptions) |> toEqual({
+          Client.Exchanges.preferGetForPersistedQueries: None,
+          generateHash: None,
         })
       })
 
-      it("should apply any specified options to the retryExchange", () => {
-        let retryExchangeOptions = Client.Exchanges.makeRetryExchangeOptions(
-          ~initialDelayMs=200,
-          ~randomDelay=false,
+      it("should apply any specified options to the persistedFetchExchange", () => {
+        let hashFn = (query, _) => Js.Promise.resolve(Js.String.normalize(query))
+
+        let persistedFetchExchangeOptions = Client.Exchanges.makePersistedFetchExchangeOptions(
+          ~preferGetForPersistedQueries=true,
+          ~generateHash=hashFn,
           (),
         )
 
         open Expect
-        expect(retryExchangeOptions) |> toEqual({
-          Client.Exchanges.initialDelayMs: Some(200),
-          maxDelayMs: None,
-          maxNumberAttempts: None,
-          randomDelay: Some(false),
-          retryIf: None,
+        expect(persistedFetchExchangeOptions) |> toEqual({
+          Client.Exchanges.preferGetForPersistedQueries: Some(true),
+          generateHash: Some(hashFn),
         })
       })
     })
@@ -267,6 +263,38 @@ describe("Client", () => {
         expect(requestPolicyExchangeOptions) |> toEqual({
           Client.Exchanges.shouldUpgrade: Some(shouldUpgrade),
           ttl: Some(2000),
+        })
+      })
+    })
+
+    describe("retryExchange", () => {
+      it("should apply the default retryExchange options from urql if none are applied", () => {
+        let retryExchangeOptions = Client.Exchanges.makeRetryExchangeOptions()
+
+        open Expect
+        expect(retryExchangeOptions) |> toEqual({
+          Client.Exchanges.initialDelayMs: None,
+          maxDelayMs: None,
+          maxNumberAttempts: None,
+          randomDelay: None,
+          retryIf: None,
+        })
+      })
+
+      it("should apply any specified options to the retryExchange", () => {
+        let retryExchangeOptions = Client.Exchanges.makeRetryExchangeOptions(
+          ~initialDelayMs=200,
+          ~randomDelay=false,
+          (),
+        )
+
+        open Expect
+        expect(retryExchangeOptions) |> toEqual({
+          Client.Exchanges.initialDelayMs: Some(200),
+          maxDelayMs: None,
+          maxNumberAttempts: None,
+          randomDelay: Some(false),
+          retryIf: None,
         })
       })
     })

--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "@glennsl/bs-jest": "^0.6.0",
     "@reasonml-community/graphql-ppx": "^1.0.1",
-    "@urql/exchange-multipart-fetch": "^0.1.11",
-    "@urql/exchange-retry": "^0.2.0",
     "all-contributors-cli": "^6.19.0",
     "babel-jest": "^26.6.3",
     "bs-platform": "^8.3.2",

--- a/src/Client.res
+++ b/src/Client.res
@@ -70,49 +70,6 @@ module Exchanges = {
   @module("urql")
   external defaultExchanges: array<t> = "defaultExchanges"
 
-  /* Ecosystem exchanges. */
-  @module("@urql/exchange-multipart-fetch")
-  external multipartFetchExchange: t = "multipartFetchExchange"
-
-  type retryExchangeOptions = {
-    initialDelayMs: option<int>,
-    maxDelayMs: option<int>,
-    randomDelay: option<bool>,
-    maxNumberAttempts: option<int>,
-    retryIf: option<(CombinedError.t, Types.operation) => bool>,
-  }
-
-  let makeRetryExchangeOptions = (
-    ~initialDelayMs=?,
-    ~maxDelayMs=?,
-    ~randomDelay=?,
-    ~maxNumberAttempts=?,
-    ~retryIf=?,
-    (),
-  ) => {
-    initialDelayMs: initialDelayMs,
-    maxDelayMs: maxDelayMs,
-    randomDelay: randomDelay,
-    maxNumberAttempts: maxNumberAttempts,
-    retryIf: retryIf,
-  }
-
-  @module("@urql/exchange-retry")
-  external retryExchange: retryExchangeOptions => t = "retryExchange"
-
-  type requestPolicyExchangeOptions = {
-    shouldUpgrade: option<Types.operation => bool>,
-    ttl: option<int>,
-  }
-
-  let makeRequestPolicyExchangeOptions = (~shouldUpgrade=?, ~ttl=?, ()) => {
-    shouldUpgrade: shouldUpgrade,
-    ttl: ttl,
-  }
-
-  @module("@urql/exchange-request-policy")
-  external requestPolicyExchange: requestPolicyExchangeOptions => t = "requestPolicyExchange"
-
   /* Specific types for the subscriptionExchange. */
   type observerLike<'value> = {
     next: 'value => unit,
@@ -169,6 +126,69 @@ module Exchanges = {
 
   @module("urql")
   external ssrExchange: (~ssrExchangeParams: ssrExchangeParams=?, unit) => t = "ssrExchange"
+
+  /* Ecosystem exchanges. */
+  @module("@urql/exchange-multipart-fetch")
+  external multipartFetchExchange: t = "multipartFetchExchange"
+
+  type persistedFetchExchangeOptions<'a> = {
+    preferGetForPersistedQueries: option<bool>,
+    generateHash: option<(string, 'a) => Js.Promise.t<string>>,
+  }
+
+  let makePersistedFetchExchangeOptions = (
+    ~preferGetForPersistedQueries=?,
+    ~generateHash=?,
+    (),
+  ) => {
+    preferGetForPersistedQueries: preferGetForPersistedQueries,
+    generateHash: generateHash,
+  }
+
+  @module("@urql/exchange-persisted-fetch")
+  external persistedFetchExchange: persistedFetchExchangeOptions<'a> => t = "persistedFetchExchange"
+
+  @module("@urql/exchange-refocus")
+  external refocusExchange: unit => t = "refocusExchange"
+
+  type requestPolicyExchangeOptions = {
+    shouldUpgrade: option<Types.operation => bool>,
+    ttl: option<int>,
+  }
+
+  let makeRequestPolicyExchangeOptions = (~shouldUpgrade=?, ~ttl=?, ()) => {
+    shouldUpgrade: shouldUpgrade,
+    ttl: ttl,
+  }
+
+  @module("@urql/exchange-request-policy")
+  external requestPolicyExchange: requestPolicyExchangeOptions => t = "requestPolicyExchange"
+
+  type retryExchangeOptions = {
+    initialDelayMs: option<int>,
+    maxDelayMs: option<int>,
+    randomDelay: option<bool>,
+    maxNumberAttempts: option<int>,
+    retryIf: option<(CombinedError.t, Types.operation) => bool>,
+  }
+
+  let makeRetryExchangeOptions = (
+    ~initialDelayMs=?,
+    ~maxDelayMs=?,
+    ~randomDelay=?,
+    ~maxNumberAttempts=?,
+    ~retryIf=?,
+    (),
+  ) => {
+    initialDelayMs: initialDelayMs,
+    maxDelayMs: maxDelayMs,
+    randomDelay: randomDelay,
+    maxNumberAttempts: maxNumberAttempts,
+    retryIf: retryIf,
+  }
+
+  @module("@urql/exchange-retry")
+  external retryExchange: retryExchangeOptions => t = "retryExchange"
 }
 
 type clientOptions<'fetchOptions, 'fetchImpl> = {

--- a/src/Client.resi
+++ b/src/Client.resi
@@ -52,44 +52,6 @@ module Exchanges: {
   @module("urql")
   external defaultExchanges: array<t> = "defaultExchanges"
 
-  /* Ecosystem exchanges. */
-  @module("@urql/exchange-multipart-fetch")
-  external multipartFetchExchange: t = "multipartFetchExchange"
-
-  type retryExchangeOptions = {
-    initialDelayMs: option<int>,
-    maxDelayMs: option<int>,
-    randomDelay: option<bool>,
-    maxNumberAttempts: option<int>,
-    retryIf: option<(CombinedError.t, Types.operation) => bool>,
-  }
-
-  let makeRetryExchangeOptions: (
-    ~initialDelayMs: int=?,
-    ~maxDelayMs: int=?,
-    ~randomDelay: bool=?,
-    ~maxNumberAttempts: int=?,
-    ~retryIf: (CombinedError.t, Types.operation) => bool=?,
-    unit,
-  ) => retryExchangeOptions
-
-  @module("@urql/exchange-retry")
-  external retryExchange: retryExchangeOptions => t = "retryExchange"
-
-  type requestPolicyExchangeOptions = {
-    shouldUpgrade: option<Types.operation => bool>,
-    ttl: option<int>,
-  }
-
-  let makeRequestPolicyExchangeOptions: (
-    ~shouldUpgrade: Types.operation => bool=?,
-    ~ttl: int=?,
-    unit,
-  ) => requestPolicyExchangeOptions
-
-  @module("@urql/exchange-request-policy")
-  external requestPolicyExchange: requestPolicyExchangeOptions => t = "requestPolicyExchange"
-
   /* Specific types for the subscriptionExchange. */
   type observerLike<'value> = {
     next: 'value => unit,
@@ -137,6 +99,61 @@ module Exchanges: {
   @send external extractData: (~exchange: t) => Js.Json.t = "extractData"
   @module("urql")
   external ssrExchange: (~ssrExchangeParams: ssrExchangeParams=?, unit) => t = "ssrExchange"
+
+  /* Ecosystem exchanges. */
+  @module("@urql/exchange-multipart-fetch")
+  external multipartFetchExchange: t = "multipartFetchExchange"
+
+  type persistedFetchExchangeOptions<'a> = {
+    preferGetForPersistedQueries: option<bool>,
+    generateHash: option<(string, 'a) => Js.Promise.t<string>>,
+  }
+
+  let makePersistedFetchExchangeOptions: (
+    ~preferGetForPersistedQueries: bool=?,
+    ~generateHash: (string, 'a) => Js.Promise.t<string>=?,
+    unit,
+  ) => persistedFetchExchangeOptions<'a>
+
+  @module("@urql/exchange-persisted-fetch")
+  external persistedFetchExchange: persistedFetchExchangeOptions<'a> => t = "persistedFetchExchange"
+
+  @module("@urql/exchange-refocus")
+  external refocusExchange: unit => t = "refocusExchange"
+
+  type requestPolicyExchangeOptions = {
+    shouldUpgrade: option<Types.operation => bool>,
+    ttl: option<int>,
+  }
+
+  let makeRequestPolicyExchangeOptions: (
+    ~shouldUpgrade: Types.operation => bool=?,
+    ~ttl: int=?,
+    unit,
+  ) => requestPolicyExchangeOptions
+
+  @module("@urql/exchange-request-policy")
+  external requestPolicyExchange: requestPolicyExchangeOptions => t = "requestPolicyExchange"
+
+  type retryExchangeOptions = {
+    initialDelayMs: option<int>,
+    maxDelayMs: option<int>,
+    randomDelay: option<bool>,
+    maxNumberAttempts: option<int>,
+    retryIf: option<(CombinedError.t, Types.operation) => bool>,
+  }
+
+  let makeRetryExchangeOptions: (
+    ~initialDelayMs: int=?,
+    ~maxDelayMs: int=?,
+    ~randomDelay: bool=?,
+    ~maxNumberAttempts: int=?,
+    ~retryIf: (CombinedError.t, Types.operation) => bool=?,
+    unit,
+  ) => retryExchangeOptions
+
+  @module("@urql/exchange-retry")
+  external retryExchange: retryExchangeOptions => t = "retryExchange"
 }
 
 let make: (

--- a/yarn.lock
+++ b/yarn.lock
@@ -918,37 +918,12 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@urql/core@>=1.14.1", "@urql/core@>=1.15.0":
-  version "1.16.1"
-  resolved "https://registry.yarnpkg.com/@urql/core/-/core-1.16.1.tgz#a41487dd4436cbdc92fce714c6c1fc04315761d3"
-  integrity sha512-lcEMCS/rB+ug7jKSRDVZIsqNhZxRooTNa1kHfvSjJT2k4SXDyPmjNSfXBUJF2pDJmvv9EIKl9Tk0AF1CvG3Q/g==
-  dependencies:
-    "@graphql-typed-document-node/core" "^3.1.0"
-    wonka "^4.0.14"
-
 "@urql/core@^1.15.1":
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/@urql/core/-/core-1.15.1.tgz#fa49909f2841d092796dd540cef6e9df89222560"
   integrity sha512-a05ablx/aKNCUc9dEbx0GvE28UC0sJ1FmfsSfmJNqecYlYeb4XvSQW4FLVy0e/MjQeB9op/weiVIEw+za2ssGw==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.0"
-    wonka "^4.0.14"
-
-"@urql/exchange-multipart-fetch@^0.1.11":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@urql/exchange-multipart-fetch/-/exchange-multipart-fetch-0.1.11.tgz#8cbd1a8d2a2f480eec2124619fb3752a9f4273f9"
-  integrity sha512-bL42HxTVLISvOpgzQvXB4ukGLJGFQA9uCidFejiDw5uOKhhx0y0BdiasA1kGu6rsQ3eBmGdEIL7fDjxy9XLqDQ==
-  dependencies:
-    "@urql/core" ">=1.14.1"
-    extract-files "^8.1.0"
-    wonka "^4.0.14"
-
-"@urql/exchange-retry@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@urql/exchange-retry/-/exchange-retry-0.2.0.tgz#e90a99bf8280ad2b8926bea7f2157a6f59dc8aec"
-  integrity sha512-eawDIkTSVudv+zMaOlm898UX9lkJnUry2PYqD7INeFWghkHmlIPm6wg5J/GBGAyFjqaOj1OWgAWYcu7sV4eljg==
-  dependencies:
-    "@urql/core" ">=1.15.0"
     wonka "^4.0.14"
 
 abab@^2.0.3:
@@ -1819,11 +1794,6 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-extract-files@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-8.1.0.tgz#46a0690d0fe77411a2e3804852adeaa65cd59288"
-  integrity sha512-PTGtfthZK79WUMk+avLmwx3NGdU8+iVFXC2NMGxKsn0MnihOG2lvumj+AZo8CTwTrwjXDgZ5tztbRlEdRjBonQ==
 
 extsprintf@1.3.0:
   version "1.3.0"


### PR DESCRIPTION
This PR adds bindings for two more exchanges 🎉:

1. `@urql/exchange-persisted-fetch`
2. `@urql/exchange-refocus`

The diff is a touch wonky because I did some additional reorganization, including organizing exchanges alphabetically in source, tests, and docs. Rest assured, there were no changes to any of the other recently bound exchanges, just moving them around.

With respect to the `persistedFetchExchange`, I left out a more extensive binding for [`DocumentNode`](https://github.com/graphql/graphql-js/blob/master/src/language/ast.d.ts#L212) in favor of a type parameter, because a full `DocumentNode` binding is _way_ outside the scope of this library. This way, users can annotate the node for the access pattern they have (be it `document.documentId` or something else).