### PR TITLE
feat: rename package to @urql/rescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "reason-urql",
-  "version": "3.4.0",
+  "name": "@urql/rescript",
+  "version": "4.0.0",
   "scripts": {
     "build": "bsb -make-world",
     "clean": "bsb -clean-world",


### PR DESCRIPTION
A tiny, smol change before the dawn of a new package name! I just wanted to get one final sign-off on the name change.

The strategy for publishing will be to:

- Merge this PR
- Publish this new version of `@urql/rescript` as v4.0.0 to continue the version continuity
- `npm deprecate` the latest version of `reason-urql` (v3.4.0) with a notice on the upgrade path

Ultimately, I settled on `@urql/rescript` for the naming of this package because it consistently follows the pattern set out by other language / framework bindings we have for `urql`, i.e. `@urql/vue`, `@urql/preact`, and `@urql/svelte`. If we do publish the bindings to `@urql/core` separately one day, I think `@urql/rescript-core` would work just fine 👍 