### PR TITLE
(docs) fix switch statement for CombinedError

### DIFF
--- a/docs/error.md
+++ b/docs/error.md
@@ -39,7 +39,7 @@ switch (response) {
         ->Belt.Option.getWithDefault("Network error")
         ->React.string}
       </div>
-    | {graphQLErrors: Some(gqle)} =>
+    | {graphQLErrors: gqle} when gqle->Belt.Array.length > 0 =>
       <div>
         {gqle
           |> Array.to_list


### PR DESCRIPTION
The value under `graphQLErrors` is an array instead of an `option` so the 
example no longer compiled. Simply unwrapping the `Some` would cause 
the result to always match. Adding the extra conditional compiles down to 
a very nice set of JavaScript if-statements.

```js
      case /* Error */2 :
          var e = response._0;
          var gqle = e.graphQLErrors;
          if (e.networkError !== undefined) {
            // Handle networkError
          } else if (gqle.length !== 0) {
            // Handle GraphQL Errors
          } else {
            // Handle all other errors
          }
```