### PR TITLE
fix: prepare for repo name migration to rescript-urql

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,5 +1,5 @@
 {
-  "projectName": "reason-urql",
+  "projectName": "rescript-urql",
   "projectOwner": "FormidableLabs",
   "repoType": "github",
   "repoHost": "https://github.com",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: reason-urql CI
+name: rescript-urql CI
 on:
   push:
     branches:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-## Contributing to `reason-urql`
+## Contributing to `rescript-urql`
 
-Thank you so much for contributing to `reason-urql`! We're excited you want to help make this project better with us.
+Thank you so much for contributing to `rescript-urql`! We're excited you want to help make this project better with us.
 
-`reason-urql` follows the [all contributors spec](https://allcontributors.org/). We believe firmly that the whole community is vital to our success, not just those who contribute code. The best way to get involved is to start by familiarizing yourself with the [`urql`](https://github.com/FormidableLabs/urql/) API and getting familiar with the basics of [Reason](https://reasonml.github.io/) and [BuckleScript](https://bucklescript.github.io/).
+`rescript-urql` follows the [all contributors spec](https://allcontributors.org/). We believe firmly that the whole community is vital to our success, not just those who contribute code. The best way to get involved is to start by familiarizing yourself with the [`urql`](https://github.com/FormidableLabs/urql/) API and getting familiar with the basics of [ReScript](https://rescript-lang.org/).
 
 ### How do I contribute?
 
@@ -12,20 +12,20 @@ If you do open a pull request for a new feature or bug, please consider adding t
 
 ### How do I set up the project?
 
-This is pretty standard. Simply clone the repo locally:
+This is pretty standard. Clone the repo locally:
 
 ```sh
-git clone https://github.com/FormidableLabs/reason-urql.git
+git clone https://github.com/FormidableLabs/rescript-urql.git
 ```
 
 and install the dependencies:
 
 ```sh
-cd reason-urql
+cd rescript-urql
 yarn
 ```
 
-We _really_ recommend having an editor plugin to run `refmt`, provide inline type annotations, and provide syntax highlighting. [`reason-language-server`](https://github.com/jaredly/reason-language-server) by Jared Forsyth is really excellent for providing all of these features out of the box!
+We _really_ recommend having an editor plugin to run the ReScript language server. For VSCode users, [`rescript-vscode`](https://github.com/rescript-lang/rescript-vscode) is the best option.
 
 #### Compiling the Source
 
@@ -83,26 +83,30 @@ To get coverage statistics:
 yarn coverage
 ```
 
-#### `refmt`
+#### Formatting
 
-You can install `refmt` globally by following the installation instructions for [`reason-cli`](https://github.com/reasonml/reason-cli). This will put a lot of nice helpers in your path. You can run `refmt` over the source using the CLI:
-
-```sh
-refmt --in-place src/*.re
-```
-
-We recommend letting the editor take care of this for you by installing `reason-language-server`. We don't currently enforce a specific `refmt` version, but please always attempt to use the latest version for your OS.
+Formatting will be handled automatically for you by [`rescript-vscode`](https://github.com/rescript-lang/rescript-vscode). If you're using a different editor than VSCode, check out [the official ReScript plugins](https://rescript-lang.org/docs/manual/latest/editor-plugins) for your editor of choice.
 
 ### Publishing
 
-When it comes time to publish a new version of `reason-urql`, we follow a pretty standard workflow using [semantic versioning](https://semver.org/). **Make sure you have, and are on, latest `master` before publishing.**
+Prior to publishing to `npm`, please consider drafting a release. We like follow the format outlined by [Keep a Changleog](https://keepachangelog.com/en/1.0.0/). To draft a release, add a new entry to CHANGELOG.md. Commit this change in a separate commit following the format:
 
 ```sh
+git commit -m "Prepare vX.X.X release."
+git push origin main
+```
+
+#### Publishing to NPM
+
+Once you've added the CHANGELOG update and pushed the commit, you're ready to publish. We follow a pretty standard workflow using [semantic versioning](https://semver.org/). **Make sure you are on latest `main` before publishing.**
+
+```sh
+git pull origin main
+
+# Assuming you have latest main...
 yarn version --<major | minor | patch>
 yarn publish
 git push && git push --tags
 ```
 
-#### Drafting a Release
-
-Once you have succesfully published to `npm`, please consider [drafting a release](https://github.com/FormidableLabs/reason-urql/releases). We like to follow the format outlined by [Keep a Changleog](https://keepachangelog.com/en/1.0.0/). In addition to drafting a release, please also update the CHANGELOG after publishing with the same copy you used to draft the release.
+Once the release is published, make sure you copy the CHANGELOG update to [the formal releases page](https://github.com/FormidableLabs/rescript-urql/releases).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Formatting will be handled automatically for you by [`rescript-vscode`](https://
 
 ### Publishing
 
-Prior to publishing to `npm`, please consider drafting a release. We like follow the format outlined by [Keep a Changleog](https://keepachangelog.com/en/1.0.0/). To draft a release, add a new entry to CHANGELOG.md. Commit this change in a separate commit following the format:
+Prior to publishing to `npm`, please consider drafting a release. We like to follow the format outlined by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). To draft a release, add a new entry to CHANGELOG.md. Commit this change in a separate commit following the format:
 
 ```sh
 git commit -m "Prepare vX.X.X release."
@@ -109,4 +109,4 @@ yarn publish
 git push && git push --tags
 ```
 
-Once the release is published, make sure you copy the CHANGELOG update to [the formal releases page](https://github.com/FormidableLabs/rescript-urql/releases).
+Once the release is published, make sure you copy the CHANGELOG update to [the formal Releases page](https://github.com/FormidableLabs/rescript-urql/releases).

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# reason-urql
+# rescript-urql
 
-[![npm](https://img.shields.io/npm/v/reason-urql.svg)](https://www.npmjs.com/package/reason-urql)
+[![npm](https://img.shields.io/npm/v/@urql/rescript.svg)](https://www.npmjs.com/package/@urql/rescript)
 [![All Contributors](https://img.shields.io/badge/all_contributors-20-orange.svg)](#contributors)
-[![Build Status](https://github.com/FormidableLabs/reason-urql/workflows/reason-urql%20CI/badge.svg)](https://github.com/FormidableLabs/reason-urql/actions?query=workflow%3A%22reason-urql+CI%22)
+[![Build Status](https://github.com/FormidableLabs/rescript-urql/workflows/rescript-urql%20CI/badge.svg)](https://github.com/FormidableLabs/rescript-urql/actions?query=workflow%3A%22rescript-urql+CI%22)
 [![Maintenance Status][maintenance-image]](#maintenance-status)
 
-Reason bindings for Formidable's Universal React Query Library, [`urql`](https://github.com/FormidableLabs/urql).
+ReScript bindings for Formidable's Universal React Query Library, [`urql`](https://github.com/FormidableLabs/urql).
 
 ## ✨Features
 
-- ⚛️ A fully featured GraphQL client for ReasonReact.
+- ⚛️ A fully featured GraphQL client for `rescript-react`.
 - ✅ Compile time type and schema validation.
 - ⚙️ Customizable behavior via `exchanges`.
 - 🎣 Support for `useQuery`, `useMutation`, `useSubscription`, and `useClient` hooks!
 - ⚡ Support for server-side rendering with Next.js.
 
-`reason-urql` is a GraphQL client for ReasonReact, allowing you to hook up your ReasonReact components to queries, mutations, and subscriptions. It provides bindings to `urql` that allow you to use the API in Reason, with the benefits of a sound type system, blazing fast compilation, and opportunities for guided customization.
+`rescript-urql` is a GraphQL client for `rescript-react`, allowing you to hook up your components to queries, mutations, and subscriptions. It provides bindings to `urql` that allow you to use the API in ReScript, with the benefits of a sound type system, blazing fast compilation, and opportunities for guided customization.
 
 ## 📋 Documentation
 
@@ -28,14 +28,14 @@ Reason bindings for Formidable's Universal React Query Library, [`urql`](https:/
 
 ## 💾 Installation
 
-### 1. Install `reason-urql` alongside its `peerDependencies` and `devDependencies`.
+### 1. Install `@urql/rescript` alongside its `peerDependencies` and `devDependencies`.
 
 ```sh
-yarn add reason-urql urql graphql
+yarn add @urql/rescript urql graphql
 yarn add gentype --dev
 ```
 
-We try to keep our bindings as close to latest `urql` as possible. However, `urql` tends to make releases a bit ahead of `reason-urql`. To get a compatible version, we recommend always staying strictly within this project's `peerDependency` range for `urql`.
+We try to keep our bindings as close to latest `urql` as possible. However, `urql` tends to make releases a bit ahead of `rescript-urql`. To get a compatible version, we recommend always staying strictly within this project's `peerDependency` range for `urql`.
 
 The `gentype` `devDependency` is a requirement introduced by `urql`'s use of `wonka`. `wonka`'s source uses `@genType` declarations, so when the BuckleScript / ReScript compiler attempts to compile `wonka` in your project, it'll need a local copy of `gentype` to use.
 
@@ -63,12 +63,12 @@ yarn add @reasonml-community/graphql-ppx --dev
 
 ### 3. Update `bsconfig.json`.
 
-Add `reason-urql`, `wonka`, and `@reasonml-community/graphql-ppx` to your `bs-dependencies` and `@reasonml-community/graphql-ppx/ppx` to your `ppx_flags` in `bsconfig.json`.
+Add `@urql/rescript`, `wonka`, and `@reasonml-community/graphql-ppx` to your `bs-dependencies` and `@reasonml-community/graphql-ppx/ppx` to your `ppx_flags` in `bsconfig.json`.
 
 ```json
 {
   "bs-dependencies": [
-    "reason-urql",
+    "@urql/rescript",
     "wonka",
     "@reasonml-community/graphql-ppx"
   ],
@@ -90,7 +90,7 @@ Simply re-run this script at anytime to regenerate the `graphql_schema.json` fil
 
 ## 💻 Example Projects
 
-`reason-urql` has a nice set of examples showing how to use the hooks and client APIs to get the most out of GraphQL and Reason in your app – check them out in the `/examples` folder. To run any of the examples, follow these steps.
+`rescript-urql` has a nice set of examples showing how to use the hooks and client APIs to get the most out of GraphQL and ReScript in your app – check them out in the `/examples` folder. To run any of the examples, follow these steps.
 
 ```sh
 # 1. Navigate into the example of choice.
@@ -108,9 +108,9 @@ yarn start:demo
 
 The example will start up at `http://localhost:3000`. Edit the example freely to watch changes take effect.
 
-### Editing `reason-urql` source files
+### Editing `rescript-urql` source files
 
-If developing on the main `reason-urql` source files (i.e. anything in `/src/`) and you want to test the changes in one of the examples, you'll need to do the following:
+If developing on the main `rescript-urql` source files (i.e. anything in `/src/`) and you want to test the changes in one of the examples, you'll need to do the following:
 
 ```sh
 # Save your changes to source, then take the following steps.
@@ -127,11 +127,11 @@ yarn clean
 yarn
 ```
 
-Since we are `link`ing the examples' dependency on `reason-urql` to the `src` directory, it's important to clean builds between changes to prevent any stale or erroneous artifacts.
+Since we are `link`ing the examples' dependency on `rescript-urql` to the `src` directory, it's important to clean builds between changes to prevent any stale or erroneous artifacts.
 
 ## Getting Involved
 
-Please help out by [opening an issue](https://github.com/FormidableLabs/reason-urql/issues) or [filing a PR](https://github.com/FormidableLabs/reason-urql/pulls).
+Please help out by [opening an issue](https://github.com/FormidableLabs/rescript-urql/issues) or [filing a PR](https://github.com/FormidableLabs/rescript-urql/pulls).
 
 ## Contributors
 
@@ -142,32 +142,32 @@ This project follows the [all contributors spec](https://github.com/kentcdodds/a
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="http://parkerziegler.com/"><img src="https://avatars0.githubusercontent.com/u/19421190?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Parker Ziegler</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=parkerziegler" title="Code">💻</a> <a href="https://github.com/FormidableLabs/reason-urql/commits?author=parkerziegler" title="Documentation">📖</a> <a href="https://github.com/FormidableLabs/reason-urql/pulls?q=is%3Apr+reviewed-by%3Aparkerziegler" title="Reviewed Pull Requests">👀</a> <a href="#ideas-parkerziegler" title="Ideas, Planning, & Feedback">🤔</a></td>
-    <td align="center"><a href="https://khoanguyen.me"><img src="https://avatars2.githubusercontent.com/u/3049054?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Khoa Nguyen</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=thangngoc89" title="Code">💻</a> <a href="https://github.com/FormidableLabs/reason-urql/commits?author=thangngoc89" title="Documentation">📖</a></td>
+    <td align="center"><a href="http://parkerziegler.com/"><img src="https://avatars0.githubusercontent.com/u/19421190?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Parker Ziegler</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=parkerziegler" title="Code">💻</a> <a href="https://github.com/FormidableLabs/rescript-urql/commits?author=parkerziegler" title="Documentation">📖</a> <a href="https://github.com/FormidableLabs/rescript-urql/pulls?q=is%3Apr+reviewed-by%3Aparkerziegler" title="Reviewed Pull Requests">👀</a> <a href="#ideas-parkerziegler" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://khoanguyen.me"><img src="https://avatars2.githubusercontent.com/u/3049054?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Khoa Nguyen</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=thangngoc89" title="Code">💻</a> <a href="https://github.com/FormidableLabs/rescript-urql/commits?author=thangngoc89" title="Documentation">📖</a></td>
     <td align="center"><a href="https://twitter.com/_philpl"><img src="https://avatars0.githubusercontent.com/u/2041385?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Phil Plückthun</b></sub></a><br /><a href="#ideas-kitten" title="Ideas, Planning, & Feedback">🤔</a></td>
-    <td align="center"><a href="https://github.com/kiraarghy"><img src="https://avatars2.githubusercontent.com/u/21056165?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kara Stubbs</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=kiraarghy" title="Code">💻</a> <a href="https://github.com/FormidableLabs/reason-urql/commits?author=kiraarghy" title="Tests">⚠️</a> <a href="#example-kiraarghy" title="Examples">💡</a></td>
-    <td align="center"><a href="https://github.com/oddlyfunctional"><img src="https://avatars1.githubusercontent.com/u/565635?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Marcos Felipe Pimenta Rodrigues</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=oddlyfunctional" title="Documentation">📖</a></td>
-    <td align="center"><a href="https://github.com/gugahoa"><img src="https://avatars2.githubusercontent.com/u/1438470?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Gustavo Aguiar</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=gugahoa" title="Code">💻</a> <a href="#example-gugahoa" title="Examples">💡</a></td>
+    <td align="center"><a href="https://github.com/kiraarghy"><img src="https://avatars2.githubusercontent.com/u/21056165?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kara Stubbs</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=kiraarghy" title="Code">💻</a> <a href="https://github.com/FormidableLabs/rescript-urql/commits?author=kiraarghy" title="Tests">⚠️</a> <a href="#example-kiraarghy" title="Examples">💡</a></td>
+    <td align="center"><a href="https://github.com/oddlyfunctional"><img src="https://avatars1.githubusercontent.com/u/565635?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Marcos Felipe Pimenta Rodrigues</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=oddlyfunctional" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/gugahoa"><img src="https://avatars2.githubusercontent.com/u/1438470?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Gustavo Aguiar</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=gugahoa" title="Code">💻</a> <a href="#example-gugahoa" title="Examples">💡</a></td>
   </tr>
   <tr>
-    <td align="center"><a href="https://github.com/Schmavery"><img src="https://avatars1.githubusercontent.com/u/2154522?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Avery Morin</b></sub></a><br /><a href="#ideas-Schmavery" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/FormidableLabs/reason-urql/commits?author=Schmavery" title="Code">💻</a> <a href="#example-Schmavery" title="Examples">💡</a> <a href="https://github.com/FormidableLabs/reason-urql/commits?author=Schmavery" title="Documentation">📖</a></td>
-    <td align="center"><a href="https://medium.com/@idkjs"><img src="https://avatars1.githubusercontent.com/u/2370391?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alain Armand</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=idkjs" title="Code">💻</a> <a href="#example-idkjs" title="Examples">💡</a></td>
-    <td align="center"><a href="http://weser.io"><img src="https://avatars0.githubusercontent.com/u/10060928?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Robin Weser</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=robinweser" title="Documentation">📖</a></td>
-    <td align="center"><a href="https://ce.ms"><img src="https://avatars3.githubusercontent.com/u/959142?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Cem Turan</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=cem2ran" title="Documentation">📖</a></td>
-    <td align="center"><a href="https://www.huy.dev/"><img src="https://avatars1.githubusercontent.com/u/7352279?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Huy Nguyen</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=huy-nguyen" title="Documentation">📖</a></td>
-    <td align="center"><a href="http://www.riseos.com"><img src="https://avatars2.githubusercontent.com/u/35296?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sean Grove</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=sgrove" title="Code">💻</a> <a href="#example-sgrove" title="Examples">💡</a> <a href="#ideas-sgrove" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/FormidableLabs/reason-urql/commits?author=sgrove" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/Schmavery"><img src="https://avatars1.githubusercontent.com/u/2154522?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Avery Morin</b></sub></a><br /><a href="#ideas-Schmavery" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/FormidableLabs/rescript-urql/commits?author=Schmavery" title="Code">💻</a> <a href="#example-Schmavery" title="Examples">💡</a> <a href="https://github.com/FormidableLabs/rescript-urql/commits?author=Schmavery" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://medium.com/@idkjs"><img src="https://avatars1.githubusercontent.com/u/2370391?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alain Armand</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=idkjs" title="Code">💻</a> <a href="#example-idkjs" title="Examples">💡</a></td>
+    <td align="center"><a href="http://weser.io"><img src="https://avatars0.githubusercontent.com/u/10060928?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Robin Weser</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=robinweser" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://ce.ms"><img src="https://avatars3.githubusercontent.com/u/959142?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Cem Turan</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=cem2ran" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://www.huy.dev/"><img src="https://avatars1.githubusercontent.com/u/7352279?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Huy Nguyen</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=huy-nguyen" title="Documentation">📖</a></td>
+    <td align="center"><a href="http://www.riseos.com"><img src="https://avatars2.githubusercontent.com/u/35296?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sean Grove</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=sgrove" title="Code">💻</a> <a href="#example-sgrove" title="Examples">💡</a> <a href="#ideas-sgrove" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/FormidableLabs/rescript-urql/commits?author=sgrove" title="Documentation">📖</a></td>
   </tr>
   <tr>
-    <td align="center"><a href="https://twitter.com/_cichocinski"><img src="https://avatars2.githubusercontent.com/u/9558691?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tomasz Cichocinski</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=baransu" title="Code">💻</a> <a href="https://github.com/FormidableLabs/reason-urql/issues?q=author%3Abaransu" title="Bug reports">🐛</a></td>
-    <td align="center"><a href="https://www.jovidecroock.com/"><img src="https://avatars3.githubusercontent.com/u/17125876?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jovi De Croock</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=JoviDeCroock" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/tatchi"><img src="https://avatars2.githubusercontent.com/u/5595092?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Corentin Leruth</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=tatchi" title="Documentation">📖</a> <a href="https://github.com/FormidableLabs/reason-urql/commits?author=tatchi" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/jeddeloh"><img src="https://avatars3.githubusercontent.com/u/1131723?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Joel Jeddeloh</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=jeddeloh" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/hulufei"><img src="https://avatars0.githubusercontent.com/u/261677?v=4?s=100" width="100px;" alt=""/><br /><sub><b>hui.liu</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=hulufei" title="Documentation">📖</a></td>
-    <td align="center"><a href="https://github.com/gaku-sei"><img src="https://avatars0.githubusercontent.com/u/3982371?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kévin Combriat</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=gaku-sei" title="Code">💻</a> <a href="https://github.com/FormidableLabs/reason-urql/issues?q=author%3Agaku-sei" title="Bug reports">🐛</a> <a href="#ideas-gaku-sei" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://twitter.com/_cichocinski"><img src="https://avatars2.githubusercontent.com/u/9558691?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tomasz Cichocinski</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=baransu" title="Code">💻</a> <a href="https://github.com/FormidableLabs/rescript-urql/issues?q=author%3Abaransu" title="Bug reports">🐛</a></td>
+    <td align="center"><a href="https://www.jovidecroock.com/"><img src="https://avatars3.githubusercontent.com/u/17125876?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jovi De Croock</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=JoviDeCroock" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/tatchi"><img src="https://avatars2.githubusercontent.com/u/5595092?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Corentin Leruth</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=tatchi" title="Documentation">📖</a> <a href="https://github.com/FormidableLabs/rescript-urql/commits?author=tatchi" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/jeddeloh"><img src="https://avatars3.githubusercontent.com/u/1131723?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Joel Jeddeloh</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=jeddeloh" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/hulufei"><img src="https://avatars0.githubusercontent.com/u/261677?v=4?s=100" width="100px;" alt=""/><br /><sub><b>hui.liu</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=hulufei" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/gaku-sei"><img src="https://avatars0.githubusercontent.com/u/3982371?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Kévin Combriat</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=gaku-sei" title="Code">💻</a> <a href="https://github.com/FormidableLabs/rescript-urql/issues?q=author%3Agaku-sei" title="Bug reports">🐛</a> <a href="#ideas-gaku-sei" title="Ideas, Planning, & Feedback">🤔</a></td>
   </tr>
   <tr>
-    <td align="center"><a href="http://amiralies.github.io"><img src="https://avatars3.githubusercontent.com/u/13261088?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Amirali Esmaeili</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=amiralies" title="Code">💻</a> <a href="#example-amiralies" title="Examples">💡</a></td>
-    <td align="center"><a href="https://www.alexandervarwijk.com"><img src="https://avatars1.githubusercontent.com/u/327697?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alexander Varwijk</b></sub></a><br /><a href="https://github.com/FormidableLabs/reason-urql/commits?author=Kingdutch" title="Code">💻</a></td>
+    <td align="center"><a href="http://amiralies.github.io"><img src="https://avatars3.githubusercontent.com/u/13261088?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Amirali Esmaeili</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=amiralies" title="Code">💻</a> <a href="#example-amiralies" title="Examples">💡</a></td>
+    <td align="center"><a href="https://www.alexandervarwijk.com"><img src="https://avatars1.githubusercontent.com/u/327697?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alexander Varwijk</b></sub></a><br /><a href="https://github.com/FormidableLabs/rescript-urql/commits?author=Kingdutch" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/__tests__/Types_test.res
+++ b/__tests__/Types_test.res
@@ -25,7 +25,7 @@ let mockOperation = {
 }
 
 describe("Types", () =>
-  describe("hookResponseToReason", () => {
+  describe("hookResponseToReScript", () => {
     it(
       "should correctly return Fetching constructor if fetching is true and no data has been received",
       () => {
@@ -41,7 +41,7 @@ describe("Types", () =>
           }
         }
         let parse = _json => ()
-        let result = Types.Hooks.hookResponseToReason(~response, ~parse)
+        let result = Types.Hooks.hookResponseToReScript(~response, ~parse)
 
         open Expect
         expect(result.response) |> toEqual(Types.Hooks.Fetching)
@@ -61,7 +61,7 @@ describe("Types", () =>
         }
       }
       let parse = json => Js.Json.decodeString(json)
-      let result = Types.Hooks.hookResponseToReason(~response, ~parse)
+      let result = Types.Hooks.hookResponseToReScript(~response, ~parse)
 
       open Expect
       expect(result.response) |> toEqual(Types.Hooks.Data(Some("Hello")))
@@ -109,7 +109,7 @@ describe("Types", () =>
         }
 
         let parse = json => Js.Json.decodeString(json)
-        let result = Types.Hooks.hookResponseToReason(~response, ~parse)
+        let result = Types.Hooks.hookResponseToReScript(~response, ~parse)
 
         open Expect
         expect(result.response) |> toEqual(
@@ -157,7 +157,7 @@ describe("Types", () =>
         }
       }
       let parse = _json => ()
-      let result = Types.Hooks.hookResponseToReason(~response, ~parse)
+      let result = Types.Hooks.hookResponseToReScript(~response, ~parse)
 
       open Expect
       expect(result.response) |> toEqual(Types.Hooks.Error(error))
@@ -176,7 +176,7 @@ describe("Types", () =>
         }
       }
       let parse = _json => ()
-      let result = Types.Hooks.hookResponseToReason(~response, ~parse)
+      let result = Types.Hooks.hookResponseToReScript(~response, ~parse)
 
       open Expect
       expect(result.response) |> toEqual(Types.Hooks.Empty)

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,6 +1,6 @@
 {
-  "name": "reason-urql",
-  "namespace": true,
+  "name": "@urql/rescript",
+  "namespace": "ReScriptUrql",
   "reason": {
     "react-jsx": 3
   },
@@ -25,7 +25,6 @@
   "suffix": ".bs.js",
   "bs-dependencies": ["@rescript/react", "wonka", "bs-fetch"],
   "bs-dev-dependencies": ["@glennsl/bs-jest"],
-  "refmt": 3,
   "warnings": {
     "error": "+5"
   }

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,10 +1,10 @@
 # Advanced
 
-Curious to know more about the internals of `reason-urql`? You've come to the right place!
+Curious to know more about the internals of `rescript-urql`? You've come to the right place!
 
 ## The `response` variant
 
-`reason-urql` uses a special `variant` called `response` to make pattern matching on the results you get from your GraphQL API as easy as possible. In JS land, users have to do something like the following:
+`rescript-urql` uses a special `variant` called `response` to make pattern matching on the results you get from your GraphQL API as easy as possible. In JS land, users have to do something like the following:
 
 ```js
 // Inside a React component
@@ -19,7 +19,7 @@ if (result.fetching) {
 return <Data data={result.data} />; // Some data UI.
 ```
 
-This is fine and works great for JS users, but we have pattern matching in Reason! Enter `reason-urql`'s `response` variant. `response` is a single variant with five constructors:
+This is fine and works great for JS users, but we have pattern matching in ReScript! Enter `rescript-urql`'s `response` variant. `response` is a single variant with five constructors:
 
 ```reason
 type response('response) {
@@ -31,7 +31,7 @@ type response('response) {
 }
 ```
 
-This variant is always available on the record returned by `reason-urql`'s hooks. Let's go over what each constructor (or "tag") means and when you'd want to pattern match on each.
+This variant is always available on the record returned by `rescript-urql`'s hooks. Let's go over what each constructor (or "tag") means and when you'd want to pattern match on each.
 
 ### The `Fetching` constructor
 
@@ -51,4 +51,4 @@ This variant is always available on the record returned by `reason-urql`'s hooks
 
 ### The `Empty` constructor
 
-The `Empty` constructor is reserved for the rare case where `reason-urql` has made a request to your GraphQL API but neither `data` nor `errors` were returned. In practice, this case is very rare. It may occur if your user goes offline unexpectedly or if your GraphQL API returns `undefined` in cases where no data matches a particular resolver. Think of it as your fallback case.
+The `Empty` constructor is reserved for the rare case where `rescript-urql` has made a request to your GraphQL API but neither `data` nor `errors` were returned. In practice, this case is very rare. It may occur if your user goes offline unexpectedly or if your GraphQL API returns `undefined` in cases where no data matches a particular resolver. Think of it as your fallback case.

--- a/docs/client-and-provider.md
+++ b/docs/client-and-provider.md
@@ -1,12 +1,12 @@
 # Client and Provider
 
-The client is the central orchestrator of `reason-urql`, and is responsible for executing queries, mutations, and subscriptions passed to `useQuery`, `useMutation`, and `useSubscription`. The `Provider` wraps the root of your application and passes your `reason-urql` client instance, via React context, to hooks in your React tree.
+The client is the central orchestrator of `rescript-urql`, and is responsible for executing queries, mutations, and subscriptions passed to `useQuery`, `useMutation`, and `useSubscription`. The `Provider` wraps the root of your application and passes your `rescript-urql` client instance, via React context, to hooks in your React tree.
 
 ## `Provider`
 
-The `Provider`'s responsibility is to pass the `reason-urql` client instance down to `useQuery`, `useMutation`, and `useSubcription` hooks through context. Wrap the root of your application with `Provider`.
+The `Provider`'s responsibility is to pass the `rescript-urql` client instance down to `useQuery`, `useMutation`, and `useSubcription` hooks through context. Wrap the root of your application with `Provider`.
 
-You can access the `Provider` component by referencing `Context.Provider` after `open`ing `ReasonUrql`.
+You can access the `Provider` component by referencing `Context.Provider` after `open`ing `ReScriptUrql`.
 
 ### Props
 
@@ -17,7 +17,7 @@ You can access the `Provider` component by referencing `Context.Provider` after 
 ### Example
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let client = Client.make(~url="https://localhost:3000/graphql", ());
 
@@ -26,14 +26,14 @@ ReactDOMRe.renderToElementWithId(<Context.Provider value=client><App /></Context
 
 ## Client
 
-The client executes all requests in `reason-urql` and delegates all incoming responses to subscribed hooks. Its full API is below; you can also look at its associated [interface file](../src/client/Client.rei).
+The client executes all requests in `rescript-urql` and delegates all incoming responses to subscribed hooks. Its full API is below; you can also look at its associated [interface file](../src/client/Client.rei).
 
 ### Client.make
 
 Create an instance of an `urql` client.
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let client = Client.make(~url="https://localhost:3000/graphql", ());
 ```
@@ -58,7 +58,7 @@ let client = Client.make(~url="https://localhost:3000/graphql", ());
 **Create a client with just a `url`.**
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let client = Client.make(~url="https://localhost:3000/graphql", ());
 ```
@@ -66,7 +66,7 @@ let client = Client.make(~url="https://localhost:3000/graphql", ());
 **Create a client with `fetchOptions`.**
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let fetchOptions =
   Client.FetchOpts(Fetch.RequestInit.make(
@@ -80,7 +80,7 @@ let client = Client.make(~url="https://localhost:3000/graphql", ~fetchOptions, (
 **Create a client with `exchanges`.**
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let client = Client.(
   make(
@@ -132,7 +132,7 @@ Imperatively execute a GraphQL query operation.
 #### Example
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let client = Client.make(~url="https://localhost:3000/graphql", ());
 
@@ -169,7 +169,7 @@ The same as `Client.executeQuery`, but returns a `Js.Promise.t` rather than a `w
 #### Example
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let client = Client.make(~url="https://localhost:3000/graphql", ());
 
@@ -221,7 +221,7 @@ Execute a GraphQL mutation operation.
 #### Example
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let client = Client.make(~url="https://localhost:3000/graphql", ());
 
@@ -258,7 +258,7 @@ The same as `Client.executeMutation`, but returns a `Js.Promise.t` rather than a
 #### Example
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let client = Client.make(~url="https://localhost:3000/graphql", ());
 
@@ -308,7 +308,7 @@ Execute a GraphQL subscription operation. If using the `executeSubscription` met
 #### Example
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 module SubscribeMessages = [%graphql
   {|

--- a/docs/error.md
+++ b/docs/error.md
@@ -1,6 +1,6 @@
 ## `CombinedError`
 
-Errors in `reason-urql` are handed to your hooks via a record of type `CombinedError.t`. The record has the following type:
+Errors in `rescript-urql` are handed to your hooks via a record of type `CombinedError.t`. The record has the following type:
 
 ```reason
 type t = {

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -1,12 +1,12 @@
 # Exchanges
 
-Exchanges are the mechanism by which `reason-urql` modifies requests before they are sent to your GraphQL API and alters responses as they are received. If you want to add some additional functionality to your GraphQL operations, this is a great place to do that.
+Exchanges are the mechanism by which `rescript-urql` modifies requests before they are sent to your GraphQL API and alters responses as they are received. If you want to add some additional functionality to your GraphQL operations, this is a great place to do that.
 
-The `Exchanges` `module` is a submodule of the `Client` module and can be referenced at `ReasonUrql.Client.Exchanges`. The following exchanges are provided out of the box with `reason-urql`.
+The `Exchanges` `module` is a submodule of the `Client` module and can be referenced at `ReScriptUrql.Client.Exchanges`. The following exchanges are provided out of the box with `rescript-urql`.
 
 ## Core Exchanges
 
-`urql` ships with a set of core exchanges that are baked right into `@urql/core` and can be referenced safely in `reason-urql` without installing any additional packages. These are detailed below.
+`urql` ships with a set of core exchanges that are baked right into `@urql/core` and can be referenced safely in `rescript-urql` without installing any additional packages. These are detailed below.
 
 ### `cacheExchange`
 
@@ -22,10 +22,10 @@ The `fetchExchange` is responsible for actually sending your request to your Gra
 
 ### `defaultExchanges`
 
-The above three exchanges make up `urql`'s `defaultExchanges`. When you create a client in `reason-urql` these exchanges are already applied by default. If you specify an `exchanges` array, be sure to include the specific exchanges you need. You almost always want the `defaultExchanges`, so make sure to include them using `Array.concat` or `Array.append`.
+The above three exchanges make up `urql`'s `defaultExchanges`. When you create a client in `rescript-urql` these exchanges are already applied by default. If you specify an `exchanges` array, be sure to include the specific exchanges you need. You almost always want the `defaultExchanges`, so make sure to include them using `Array.concat` or `Array.append`.
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let client = Client.(
   make(
@@ -61,11 +61,11 @@ let subscriptionClient =
     (),
   );
 
-/* Implement the forwardSubscription function. This tells reason-urql how to handle
+/* Implement the forwardSubscription function. This tells rescript-urql how to handle
 incoming operations of operationType 'subscription'. */
 let forwardSubscription = operation => subscriptionClient##request(operation);
 
-/* Confirgure options for reason-urql's subscriptionExchange. */
+/* Confirgure options for rescript-urql's subscriptionExchange. */
 let subscriptionExchangeOpts =
   Client.Exchanges.{forwardSubscription: forwardSubscription};
 
@@ -88,12 +88,12 @@ let client = Client.(
 The `ssrExchange` accepts a single optional argument, `~ssrExchangeParams`, a record with two fields:
 
 - `~initialState` - which populates the server-side rendered data with a rehydrated cache.
-- `~isClient` – tell the exchange whether or not it is executing on the client or the server. By default, `reason-urql` will look at the `suspense` parameter passed to the client to determine this if `isClient` is not provided.
+- `~isClient` – tell the exchange whether or not it is executing on the client or the server. By default, `rescript-urql` will look at the `suspense` parameter passed to the client to determine this if `isClient` is not provided.
 
 If using the `ssrExchange`, it should be placed after any caching exchanges, like `cacheExchange`, but before any asynchronous exchanges, like `fetchExchange`.
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let ssrCache = Exchanges.ssrExchange();
 
@@ -116,7 +116,7 @@ The resulting data structure returned from creating the `ssrExchange` can be acc
 - `extractData` – this is typically used on the server-side to extract data returned from your GraphQL requests after they've been executed on the server.
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let ssrCache = Client.Exchanges.ssrExchange(~ssrExchangeParams, ());
 
@@ -127,7 +127,7 @@ let extractedData = Client.Exchanges.extractData(~exchange=ssrCache);
 - `restoreData` is typically used to rehydrate the client with data from the server. The `restore` argument is what allows you to reference the data returned from the server to the client.
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let ssrCache = Client.Exchanges.ssrExchange(~ssrExchangeParams, ());
 
@@ -135,7 +135,7 @@ let ssrCache = Client.Exchanges.ssrExchange(~ssrExchangeParams, ());
 let extractedData = Client.Exchanges.restoreData(~exchange=ssrCache, ~restore=urqlData);
 ```
 
-This part of the API is still quite experimental, as server-side rendering in Reason with Next.js is still in its infancy. Use with caution. For more information, read `urql`'s server-side rendering guide [here](https://github.com/FormidableLabs/urql/blob/master/docs/basics.md#server-side-rendering). To see an example of server-side rendering with `reason-urql`, check out our [`reason-urql-ssr` example](https://github.com/parkerziegler/reason-urql-ssr).
+This part of the API is still quite experimental, as server-side rendering in ReScript with Next.js is still in its infancy. Use with caution. For more information, read `urql`'s server-side rendering guide [here](https://github.com/FormidableLabs/urql/blob/master/docs/basics.md#server-side-rendering). To see an example of server-side rendering with `rescript-urql`, check out our [SSR example](https://github.com/parkerziegler/rescript-urql-ssr).
 
 ### `composeExchanges`
 
@@ -143,7 +143,7 @@ This part of the API is still quite experimental, as server-side rendering in Re
 
 ## Ecosystem Exchanges
 
-In addition to the core exchanges exposed by `@urql/core`, `urql` also supports more abstracted exchanges that meet particular needs that may or may not be critical to your use case. In contrast to the core exchanges, these ecosystem exchanges should be used when you have a specific use case that warrants them. Many of these exchanges require additional packages to be installed. `reason-urql` is in the process of adding bindings for these exchanges; if the ecosystem exchange you're interested in isn't outlined below, the bindings may not have yet been implemented. Community contributions are very welcome in this space!
+In addition to the core exchanges exposed by `@urql/core`, `urql` also supports more abstracted exchanges that meet particular needs that may or may not be critical to your use case. In contrast to the core exchanges, these ecosystem exchanges should be used when you have a specific use case that warrants them. Many of these exchanges require additional packages to be installed. `rescript-urql` is in the process of adding bindings for these exchanges; if the ecosystem exchange you're interested in isn't outlined below, the bindings may not have yet been implemented. Community contributions are very welcome in this space!
 
 ### `multipartFetchExchange`
 
@@ -158,7 +158,7 @@ yarn add @urql/exchange-multipart-fetch
 Then, substitute the `fetchExchange` with the `multipartFetchExchange`:
 
 ```rescript
-open ReasonUrql
+open ReScriptUrql
 
 let client = Client.make(
   ~url="http://localhost:3000",
@@ -186,7 +186,7 @@ yarn add @urql/exchange-persisted-fetch
 Then, add the exchange to your array of `exchanges`, sepcifying the options you want to configure:
 
 ```rescript
-open ReasonUrql
+open ReScriptUrql
 
 let persistedFetchExchangeOptions = Client.Exchanges.makePersistedFetchExchangeOptions(
   ~preferGetForPersistedQueries=true,
@@ -211,7 +211,7 @@ Read more about the `persistedFetchExchange` [here](https://github.com/Formidabl
 
 ### `refocusExchange`
 
-The `refocusExchange` allows `reason-urql` to redispatch active operations when the window regains focus.
+The `refocusExchange` allows `rescript-urql` to redispatch active operations when the window regains focus.
 
 To use the `refocusExchange`, add the package to your dependencies:
 
@@ -222,7 +222,7 @@ yarn add @urql/exchange-refocus
 Then, add the exchange to your array of `exchanges`. The `refocusExchange` should be added _after_ the `dedupeExchange`, to prevent doing additional work on requests that are later deduplicated, and _before_ the `fetchExchange`:
 
 ```rescript
-open ReasonUrql
+open ReScriptUrql
 
 let client = Client.make(
   ~url="http://localhost:3000",
@@ -238,7 +238,7 @@ let client = Client.make(
 
 ### `requestPolicyExchange`
 
-The `requestPolicyExchange` allows `reason-urql` to automatically upgrade an operation's `requestPolicy` on a time-to-live basis. When the specified TTL has elapsed, `reason-urql` will either:
+The `requestPolicyExchange` allows `rescript-urql` to automatically upgrade an operation's `requestPolicy` on a time-to-live basis. When the specified TTL has elapsed, `rescript-urql` will either:
 
 - Upgrade the `requestPolicy` of the operation to `cache-and-network` if no `shouldUpgrade` callback is specified, or:
 - Run the `shouldUpgrade` function to determine whether or not to upgrade the specific operation.
@@ -252,7 +252,7 @@ yarn add @urql/exchange-request-policy
 Then, add the exchange to your array of `exchanges`, specifying the options you want to configure:
 
 ```rescript
-open ReasonUrql
+open ReScriptUrql
 
 let shouldUpgrade = (operation: Types.operation) =>
   operation.context.requestPolicy !== #CacheOnly
@@ -290,7 +290,7 @@ yarn add @urql/exchange-retry
 Then, add the exchange to your array of `exchanges`, specifying the options you want to configure:
 
 ```rescript
-open ReasonUrql
+open ReScriptUrql
 
 let retryExchangeOptions =
   Client.Exchanges.makeRetryExchangeOptions(~initialDelayMs=2000, ~randomDelay=false, ())
@@ -322,7 +322,7 @@ By default, `urql` will apply the following configuration for you:
 If you want to use the defaults from `urql`, call `makeRetryExchangeOptions` with just a `unit` parameter.
 
 ```rescript
-open ReasonUrql
+open ReScriptUrql
 
 let retryExchangeOptions =
   Client.Exchanges.makeRetryExchangeOptions()
@@ -343,9 +343,9 @@ Read more on the `retryExchange` [here](https://formidable.com/open-source/urql/
 
 ## Custom Exchanges
 
-`reason-urql` also allows you to write your own exchanges to modify outgoing GraphQL requests and incoming responses. To read up on the basics of exchanges, check out the excellent [`urql` documentation](https://formidable.com/open-source/urql/docs/concepts/exchanges/).
+`rescript-urql` also allows you to write your own exchanges to modify outgoing GraphQL requests and incoming responses. To read up on the basics of exchanges, check out the excellent [`urql` documentation](https://formidable.com/open-source/urql/docs/concepts/exchanges/).
 
-The signature of an exchange in `reason-urql` is:
+The signature of an exchange in `rescript-urql` is:
 
 ```reason
 type t =
@@ -357,18 +357,18 @@ type t =
 `exchangeInput` here is a record containing two fields:
 
 - `forward` – a function for forwarding the current operation onto the next exchange.
-- `client` – your `reason-urql` client instance.
+- `client` – your `rescript-urql` client instance.
 
 Let's look at an example to see how to implement our own exchanges.
 
-#### Rewriting the `debugExchange` in Reason
+#### Rewriting the `debugExchange` in ReScript
 
-To see how we can write our own custom exchange, we'll reimplement the `urql`'s native `debugExchange` in Reason:
+To see how we can write our own custom exchange, we'll reimplement the `urql`'s native `debugExchange` in ReScript:
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
-/* This is the native debugExchange that ships with `urql`, re-implemented in Reason.
+/* This is the native debugExchange that ships with `urql`, re-implemented in ReScript.
      Typically, you'd just add Exchanges.debugExchange to the Client's exchange array.
    */
 let debugExchange = (Client.Exchanges.{forward}) =>
@@ -388,12 +388,12 @@ let debugExchange = (Client.Exchanges.{forward}) =>
        );
 ```
 
-That's it! We've successfully re-implemented `urql`'s `debugExchange` in Reason. Because the `Wonka` library used for much of `urql`'s exchange architecture is written in Reason itself, writing our own exchanges is often more ergonomic than the JS experience. When you've written your exchange, just supply it to your client like so:
+That's it! We've successfully re-implemented `urql`'s `debugExchange` in ReScript. Because the `Wonka` library used for much of `urql`'s exchange architecture is written in ReScript itself, writing our own exchanges is often more ergonomic than the JS experience. When you've written your exchange, just supply it to your client like so:
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
-/* This is the native debugExchange that ships with `urql`, re-implemented in Reason.
+/* This is the native debugExchange that ships with `urql`, re-implemented in ReScript.
      Typically, you'd just add Exchanges.debugExchange to the Client's exchange array.
    */
 let debugExchange = (Client.Exchanges.{forward}) =>

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -135,7 +135,7 @@ let ssrCache = Client.Exchanges.ssrExchange(~ssrExchangeParams, ());
 let extractedData = Client.Exchanges.restoreData(~exchange=ssrCache, ~restore=urqlData);
 ```
 
-This part of the API is still quite experimental, as server-side rendering in ReScript with Next.js is still in its infancy. Use with caution. For more information, read `urql`'s server-side rendering guide [here](https://github.com/FormidableLabs/urql/blob/master/docs/basics.md#server-side-rendering). To see an example of server-side rendering with `rescript-urql`, check out our [SSR example](https://github.com/parkerziegler/rescript-urql-ssr).
+This part of the API is still quite experimental, as server-side rendering in ReScript with Next.js is still in its infancy. Use with caution. For more information, read `urql`'s server-side rendering guide [here](https://github.com/FormidableLabs/urql/blob/master/docs/basics.md#server-side-rendering). To see an example of server-side rendering with `rescript-urql`, check out our [SSR example](https://github.com/parkerziegler/reason-urql-ssr).
 
 ### `composeExchanges`
 
@@ -388,7 +388,7 @@ let debugExchange = (Client.Exchanges.{forward}) =>
        );
 ```
 
-That's it! We've successfully re-implemented `urql`'s `debugExchange` in ReScript. Because the `Wonka` library used for much of `urql`'s exchange architecture is written in ReScript itself, writing our own exchanges is often more ergonomic than the JS experience. When you've written your exchange, just supply it to your client like so:
+That's it! We've successfully re-implemented `urql`'s `debugExchange` in ReScript. Because the `Wonka` library used for much of `urql`'s exchange architecture is written in Reason, writing our own exchanges is often more ergonomic than the JS experience. When you've written your exchange, just supply it to your client like so:
 
 ```reason
 open ReScriptUrql;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,25 +1,25 @@
 # Getting Started
 
-This document well help you get started with `reason-urql`. It picks up right where the README leaves off. It assumes you've followed the installation instructions, but nothing more.
+This document well help you get started with `rescript-urql`. It picks up right where the README leaves off. It assumes you've followed the installation instructions, but nothing more.
 
 ## Setting Up the Client
 
-To get started with `reason-urql`, the first thing you'll want to do is create your client. Your client is the core orchestrator of communication with your GraphQL API, handling all outgoing requests and incoming responses. To create a client, call the `make` function from the `Client` module.
+To get started with `rescript-urql`, the first thing you'll want to do is create your client. Your client is the core orchestrator of communication with your GraphQL API, handling all outgoing requests and incoming responses. To create a client, call the `make` function from the `Client` module.
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let client = Client.make(~url="https://mygraphqlapi.com/graphql", ());
 ```
 
-The `client` accepts a few other configuration options, including `fetchOptions` and `exchanges`, but only `url` is required. By default, `reason-urql` will apply `urql`'s `defaultExchanges` if no exchanges are provided; this will include the `fetchExchange` for executing requests, the `cacheExchange` for caching responses from your API, and the `dedupExchange` for deduplicating in-flight requests. It will also apply standard fetch options if no `fetchOptions` argument is provided, using `POST` as the HTTP method and `application/json` as the `Content-Type` header. We'll see later how to work with these options.
+The `client` accepts a few other configuration options, including `fetchOptions` and `exchanges`, but only `url` is required. By default, `rescript-urql` will apply `urql`'s `defaultExchanges` if no exchanges are provided; this will include the `fetchExchange` for executing requests, the `cacheExchange` for caching responses from your API, and the `dedupExchange` for deduplicating in-flight requests. It will also apply standard fetch options if no `fetchOptions` argument is provided, using `POST` as the HTTP method and `application/json` as the `Content-Type` header. We'll see later how to work with these options.
 
 ## Linking Client with Provider
 
-Once you have your `Client` setup, you'll need to pass it to your `Provider`, which should wrap the root level of your application. This allows `reason-urql`'s hooks to access the `Client` in order to execute operations lower down in your React tree.
+Once you have your `Client` setup, you'll need to pass it to your `Provider`, which should wrap the root level of your application. This allows `rescript-urql`'s hooks to access the `Client` in order to execute operations lower down in your React tree.
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 let client = Client.make(~url="https://mygraphqlapi.com/graphql", ());
 
@@ -31,10 +31,10 @@ let make = () =>
 
 ## Using Your First Hook
 
-Nice, there's only one more step to getting our GraphQL requests executing – using a hook! `reason-urql` comes with three hooks for getting access to your data – `useQuery`, `useMutation`, and `useSubscription`. Let's check out how we might execute a query with `useQuery`.
+Nice, there's only one more step to getting our GraphQL requests executing – using a hook! `rescript-urql` comes with three hooks for getting access to your data – `useQuery`, `useMutation`, and `useSubscription`. Let's check out how we might execute a query with `useQuery`.
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 /* Create a module with your GraphQL query. */
 module DogsQuery = [%graphql
@@ -88,12 +88,12 @@ Check out the example in `examples/2-query` to see a more involved example of us
 
 ## Writing Your First Mutation
 
-Awesome, so we've written our first query with `reason-urql`. What about mutations?
+Awesome, so we've written our first query with `rescript-urql`. What about mutations?
 
-Fortunately, writing mutations in `reason-urql` is just as easy as writing queries – just use the `useMutation` hook.
+Fortunately, writing mutations in `rescript-urql` is just as easy as writing queries – just use the `useMutation` hook.
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 /* Create a module with your GraphQL mutation. */
 module LikeDogMutation = [%graphql
@@ -120,12 +120,12 @@ let make = (~key: string) => {
 }
 ```
 
-Great – we've successfully executed a mutation to like a dog! Existing queries that reference the mutated data will be notified that data has changed, meaning you don't need to think at all about refetching your data – it's all updated for you by `reason-urql`.
+Great – we've successfully executed a mutation to like a dog! Existing queries that reference the mutated data will be notified that data has changed, meaning you don't need to think at all about refetching your data – it's all updated for you by `rescript-urql`.
 
 `useMutation` returns a two-dimensional tuple, containing `(result, executeMutation)`. `result` contains the `response` variant, which allows you to pattern match on the API response from your mutation. For example, if you wanted to show different UI when your mutation was `Fetching`, or if there was an `Error` you can do something like the following:
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 [@react.component]
 let make = (~key: string) => {

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,8 +1,8 @@
 # Hooks
 
-In this section, we cover the main mechanism for requesting data in `reason-urql` – hooks!
+In this section, we cover the main mechanism for requesting data in `rescript-urql` – hooks!
 
-`reason-urql` comes with a set of custom hooks to use in your ReasonReact components, including `useQuery`, `useMutation`, and `useSubscription`. These are fully type safe and will automatically infer the type of your GraphQL response if using `graphql_ppx_re` or `graphql_ppx`.
+`rescript-urql` comes with a set of custom hooks to use in your `rescript-react` components, including `useQuery`, `useMutation`, and `useSubscription`. These are fully type safe and will automatically infer the type of your GraphQL response if using `graphql_ppx_re` or `graphql_ppx`.
 
 ## `useQuery`
 
@@ -35,7 +35,7 @@ In this section, we cover the main mechanism for requesting data in `reason-urql
 ### Example
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 module GetPokémon = [%graphql
   {|
@@ -103,7 +103,7 @@ Check out `examples/2-query` to see an example of using the `useQuery` hook.
 ### Example
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 module LikeDog = [%graphql
     {|
@@ -161,7 +161,7 @@ If using the `useSubscription` hook, be sure your client is configured with the 
 ### Example
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 module SubscribeRandomInt = [%graphql
   {|
@@ -225,7 +225,7 @@ Check out `examples/5-subscription` to see an example of using the `useSubscript
 ### Example
 
 ```reason
-open ReasonUrql;
+open ReScriptUrql;
 
 module GetAllDogs = [%graphql {|
   query dogs {

--- a/examples/1-execute-query-mutation/bsconfig.json
+++ b/examples/1-execute-query-mutation/bsconfig.json
@@ -17,12 +17,11 @@
   ],
   "suffix": ".bs.js",
   "bs-dependencies": [
-    "reason-urql",
+    "@urql/rescript",
     "@rescript/react",
     "wonka",
     "@reasonml-community/graphql-ppx"
   ],
-  "refmt": 3,
   "warnings": {
     "error": "+5"
   },

--- a/examples/1-execute-query-mutation/package.json
+++ b/examples/1-execute-query-mutation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "1-execute-query-mutation",
   "version": "0.1.0",
-  "description": "An example of how to execute one off queries and mutations using reason-urql.",
+  "description": "An example of how to execute one off queries and mutations using rescript-urql.",
   "main": "src/index.bs.js",
   "author": "Parker Ziegler <parker.ziegler@formidable.com>",
   "license": "MIT",
@@ -14,10 +14,10 @@
   "dependencies": {
     "@reasonml-community/graphql-ppx": "^1.0.1",
     "@rescript/react": "^0.10.1",
+    "@urql/rescript": "link:../../",
     "graphql": "^15.4.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "reason-urql": "link:../../",
     "urql": "^2.0.0"
   },
   "devDependencies": {

--- a/examples/1-execute-query-mutation/public/index.html
+++ b/examples/1-execute-query-mutation/public/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, minimum-scale=1"
     />
-    <title>reason-urql: Client.execute* methods</title>
+    <title>rescript-urql: Client.execute* methods</title>
     <style type="text/css">
       html {
         font-size: 10px;

--- a/examples/1-execute-query-mutation/src/Previewer.res
+++ b/examples/1-execute-query-mutation/src/Previewer.res
@@ -1,9 +1,8 @@
-open ReasonUrql
+open ReScriptUrql
 
 let client = Client.make(~url="https://formidadog-ql.netlify.app/graphql", ())
 
-module GetAllDogs = %graphql(
-  `
+module GetAllDogs = %graphql(`
   query dogs {
     dogs {
       name
@@ -11,11 +10,9 @@ module GetAllDogs = %graphql(
       likes
     }
   }
-`
-)
+`)
 
-module LikeDog = %graphql(
-  `
+module LikeDog = %graphql(`
   mutation likeDog($key: ID!) {
     likeDog(key: $key) {
       name
@@ -23,8 +20,7 @@ module LikeDog = %graphql(
       likes
     }
   }
-`
-)
+`)
 
 type state = {
   query: option<Js.Json.t>,

--- a/examples/1-execute-query-mutation/yarn.lock
+++ b/examples/1-execute-query-mutation/yarn.lock
@@ -75,6 +75,10 @@
     "@graphql-typed-document-node/core" "^3.1.0"
     wonka "^4.0.14"
 
+"@urql/rescript@link:../..":
+  version "0.0.0"
+  uid ""
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -2589,10 +2593,6 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
-
-"reason-urql@link:../..":
-  version "0.0.0"
-  uid ""
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"

--- a/examples/2-query/bsconfig.json
+++ b/examples/2-query/bsconfig.json
@@ -18,12 +18,11 @@
   ],
   "suffix": ".bs.js",
   "bs-dependencies": [
-    "reason-urql",
+    "@urql/rescript",
     "@rescript/react",
     "wonka",
     "@reasonml-community/graphql-ppx"
   ],
-  "refmt": 3,
   "warnings": {
     "error": "+5"
   },

--- a/examples/2-query/package.json
+++ b/examples/2-query/package.json
@@ -1,7 +1,7 @@
 {
   "name": "2-query",
   "version": "0.1.0",
-  "description": "An example of how to use the useQuery hook in reason-urql.",
+  "description": "An example of how to use the useQuery hook in rescript-urql.",
   "main": "src/index.bs.js",
   "author": "Kara Stubbs <kara.stubbs@formidable.com>, Parker Ziegler <parker.ziegler@formidable.com>",
   "license": "MIT",
@@ -14,10 +14,10 @@
   "dependencies": {
     "@reasonml-community/graphql-ppx": "^1.0.1",
     "@rescript/react": "^0.10.1",
+    "@urql/rescript": "link:../../",
     "graphql": "^15.4.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "reason-urql": "link:../../",
     "urql": "^2.0.0"
   },
   "devDependencies": {

--- a/examples/2-query/public/index.html
+++ b/examples/2-query/public/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, minimum-scale=1"
     />
-    <title>reason-urql: useQuery</title>
+    <title>rescript-urql: useQuery</title>
     <style type="text/css">
       html {
         font-size: 10px;

--- a/examples/2-query/src/Container.res
+++ b/examples/2-query/src/Container.res
@@ -1,15 +1,13 @@
-open ReasonUrql
+open ReScriptUrql
 
 /* Fetch all 151 original pokemon. */
-module GetAllPokemons = %graphql(
-  `
+module GetAllPokemons = %graphql(`
   query pokemons($first: Int!) {
     pokemons(first: $first) {
       name
     }
   }
-`
-)
+`)
 
 let flattenPokemon = pokemons => {
   open GetAllPokemons

--- a/examples/2-query/src/Pokemon.res
+++ b/examples/2-query/src/Pokemon.res
@@ -1,7 +1,6 @@
-open ReasonUrql
+open ReScriptUrql
 
-module GetPokemon = %graphql(
-  `
+module GetPokemon = %graphql(`
   query pokemon($name: String!) {
     pokemon(name: $name) {
       name
@@ -15,8 +14,7 @@ module GetPokemon = %graphql(
       image
     }
   }
-`
-)
+`)
 
 @react.component
 let make = (~pokemon: string) => {

--- a/examples/2-query/src/index.res
+++ b/examples/2-query/src/index.res
@@ -1,4 +1,4 @@
-open ReasonUrql
+open ReScriptUrql
 
 let client = Client.make(~url="https://graphql-pokemon2.vercel.app", ())
 

--- a/examples/2-query/yarn.lock
+++ b/examples/2-query/yarn.lock
@@ -61,13 +61,17 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.6.tgz#146d3da57b3c636cc0d1769396ce1cfa8991147f"
   integrity sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==
 
-"@urql/core@^1.15.1":
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/@urql/core/-/core-1.15.1.tgz#fa49909f2841d092796dd540cef6e9df89222560"
-  integrity sha512-a05ablx/aKNCUc9dEbx0GvE28UC0sJ1FmfsSfmJNqecYlYeb4XvSQW4FLVy0e/MjQeB9op/weiVIEw+za2ssGw==
+"@urql/core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@urql/core/-/core-2.0.0.tgz#b4936dd51fe84cb570506d9ee2579149689f7535"
+  integrity sha512-Qj24CG8ullqZZsYmjrSH0JhH+nY7kj8GbVbA9si3KUjlYs75A/MBQU3i97j6oWyGldDBapyis2CfaQeXKbv8rA==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.0"
     wonka "^4.0.14"
+
+"@urql/rescript@link:../..":
+  version "0.0.0"
+  uid ""
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -469,10 +473,10 @@ bs-fetch@^0.6.2:
   resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.6.2.tgz#37d982e9f79b9bc44c23e87ae78ccbee1f869adf"
   integrity sha512-VXEjp8kY3vHPckaoy3d96Bx0KYjJAPLNISBwfpwMN26K6DtuZYwI2HKhx7zeHBajz1bRArfx7O8OOLcdtujMvg==
 
-bs-platform@9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-9.0.1.tgz#069dae007aadb400963cec25c8349ea1f3f6cae0"
-  integrity sha512-RxUrwxVBCx9AiiyFIthZwfPn+tAn9noRHCb9xJK4Uw2deGxIytqyoWDepMbH35v7EpxX0OhfXL5RrjHTaXersA==
+bs-platform@9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-9.0.2.tgz#a6eac70eb8924a322556dacaccbfbc9b2a0d3a37"
+  integrity sha512-Ye9JqJ4Oa7mcjjoOVRYI8Uc2Cf8N7jQLWDcdUplY7996d/YErSR7WitmV7XnSwr4EvdrbwjEsg1NxNjUQv3ChA==
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -2434,10 +2438,6 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-"reason-urql@link:../..":
-  version "0.0.0"
-  uid ""
-
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -3039,12 +3039,12 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urql@~1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-1.11.2.tgz#dfc63734b26262cf4f143768f345b104094b32c0"
-  integrity sha512-1MIjOjZO5xgdqtcj9QdD2/JXpEVAl03vylaiSVm6QGqEbkBP9Zvb405QUJzCbVKH8bFoPxfcjvNAWwM8lekEMg==
+urql@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-2.0.1.tgz#16c024ab0340328001b0c400ebe1368887af3823"
+  integrity sha512-UTYLaMMw/N2iM2nHbcZ1XvN+opZxtWKwJaczV+MAco8buFpR3JR9CFrgKvx9p4uz+EayqQ69LZTWreJx+c196w==
   dependencies:
-    "@urql/core" "^1.15.1"
+    "@urql/core" "^2.0.0"
     wonka "^4.0.14"
 
 use@^3.1.0:

--- a/examples/3-mutation/bsconfig.json
+++ b/examples/3-mutation/bsconfig.json
@@ -18,12 +18,11 @@
   ],
   "suffix": ".bs.js",
   "bs-dependencies": [
-    "reason-urql",
+    "@urql/rescript",
     "@rescript/react",
     "wonka",
     "@reasonml-community/graphql-ppx"
   ],
-  "refmt": 3,
   "warnings": {
     "error": "+5"
   },

--- a/examples/3-mutation/package.json
+++ b/examples/3-mutation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "3-mutation",
   "version": "0.1.0",
-  "description": "An example of how to use the useMutation hook in reason-urql.",
+  "description": "An example of how to use the useMutation hook in rescript-urql.",
   "main": "src/index.bs.js",
   "author": "Parker Ziegler <parker.ziegler@formidable.com>",
   "license": "MIT",
@@ -14,10 +14,10 @@
   "dependencies": {
     "@reasonml-community/graphql-ppx": "^1.0.1",
     "@rescript/react": "^0.10.1",
+    "@urql/rescript": "link:../../",
     "graphql": "^15.4.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "reason-urql": "link:../../",
     "urql": "^2.0.0"
   },
   "devDependencies": {

--- a/examples/3-mutation/public/index.html
+++ b/examples/3-mutation/public/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, minimum-scale=1"
     />
-    <title>reason-urql: useMutation</title>
+    <title>rescript-urql: useMutation</title>
     <style type="text/css">
       html {
         font-size: 10px;

--- a/examples/3-mutation/src/Dog.res
+++ b/examples/3-mutation/src/Dog.res
@@ -1,44 +1,36 @@
-open ReasonUrql
+open ReScriptUrql
 
-module LikeDog = %graphql(
-  `
+module LikeDog = %graphql(`
     mutation likeDog($key: ID!) {
       likeDog(key: $key) {
         likes
       }
     }
-  `
-)
+  `)
 
-module TreatDog = %graphql(
-  `
+module TreatDog = %graphql(`
     mutation treatDog($key: ID!) {
       treatDog(key: $key) {
         treats
       }
     }
-  `
-)
+  `)
 
-module PatDog = %graphql(
-  `
+module PatDog = %graphql(`
     mutation patDog($key: ID!) {
       patDog(key: $key) {
         pats
       }
     }
-  `
-)
+  `)
 
-module BellyscratchDog = %graphql(
-  `
+module BellyscratchDog = %graphql(`
     mutation bellyscratchDog($key: ID!) {
       bellyscratchDog(key: $key) {
         bellyscratches
       }
     }
-  `
-)
+  `)
 
 @react.component
 let make = (

--- a/examples/3-mutation/src/Grid.res
+++ b/examples/3-mutation/src/Grid.res
@@ -1,7 +1,6 @@
-open ReasonUrql
+open ReScriptUrql
 
-module GetAllDogs = %graphql(
-  `
+module GetAllDogs = %graphql(`
   {
     dogs {
       key
@@ -15,8 +14,7 @@ module GetAllDogs = %graphql(
       imageUrl
     }
   }
-`
-)
+`)
 
 @react.component
 let make = () => {

--- a/examples/3-mutation/src/index.res
+++ b/examples/3-mutation/src/index.res
@@ -1,4 +1,4 @@
-open ReasonUrql
+open ReScriptUrql
 
 let client = Client.make(~url="https://formidadog-ql.netlify.app/graphql", ())
 

--- a/examples/3-mutation/yarn.lock
+++ b/examples/3-mutation/yarn.lock
@@ -69,6 +69,10 @@
     "@graphql-typed-document-node/core" "^3.1.0"
     wonka "^4.0.14"
 
+"@urql/rescript@link:../..":
+  version "0.0.0"
+  uid ""
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -2433,10 +2437,6 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
-
-"reason-urql@link:../..":
-  version "0.0.0"
-  uid ""
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"

--- a/examples/4-exchanges/bsconfig.json
+++ b/examples/4-exchanges/bsconfig.json
@@ -16,8 +16,7 @@
     }
   ],
   "suffix": ".bs.js",
-  "bs-dependencies": ["reason-urql", "@rescript/react", "wonka"],
-  "refmt": 3,
+  "bs-dependencies": ["@urql/rescript", "@rescript/react", "wonka"],
   "warnings": {
     "error": "+5"
   },

--- a/examples/4-exchanges/bsconfig.json
+++ b/examples/4-exchanges/bsconfig.json
@@ -16,7 +16,12 @@
     }
   ],
   "suffix": ".bs.js",
-  "bs-dependencies": ["@urql/rescript", "@rescript/react", "wonka"],
+  "bs-dependencies": [
+    "@urql/rescript",
+    "@rescript/react",
+    "wonka",
+    "@reasonml-community/graphql-ppx"
+  ],
   "warnings": {
     "error": "+5"
   },

--- a/examples/4-exchanges/package.json
+++ b/examples/4-exchanges/package.json
@@ -1,7 +1,7 @@
 {
   "name": "4-exchanges",
   "version": "0.1.0",
-  "description": "An example of how to use custom exchanges in reason-urql.",
+  "description": "An example of how to use custom exchanges in rescript-urql.",
   "main": "src/index.bs.js",
   "author": "Parker Ziegler <parker.ziegler@formidable.com>",
   "license": "MIT",
@@ -14,10 +14,10 @@
   "dependencies": {
     "@reasonml-community/graphql-ppx": "^1.0.1",
     "@rescript/react": "^0.10.1",
+    "@urql/rescript": "link:../../",
     "graphql": "^15.4.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "reason-urql": "link:../../",
     "urql": "^2.0.0"
   },
   "devDependencies": {

--- a/examples/4-exchanges/public/index.html
+++ b/examples/4-exchanges/public/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, minimum-scale=1"
     />
-    <title>reason-urql: Custom Exchanges</title>
+    <title>rescript-urql: Custom Exchanges</title>
     <style type="text/css">
       html {
         font-size: 10px;

--- a/examples/4-exchanges/src/index.res
+++ b/examples/4-exchanges/src/index.res
@@ -1,6 +1,6 @@
-open ReasonUrql
+open ReScriptUrql
 
-/* This is the native debugExchange that ships with `urql`, re-implemented in Reason.
+/* This is the native debugExchange that ships with `urql`, re-implemented in ReScript.
      Typically, you'd just add Exchanges.debugExchange to the Client's exchange array.
  */
 let debugExchange = ({Client.Exchanges.forward: forward}, . ops) =>

--- a/examples/4-exchanges/yarn.lock
+++ b/examples/4-exchanges/yarn.lock
@@ -67,13 +67,17 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.11.7.tgz#57682a9771a3f7b09c2497f28129a0462966524a"
   integrity sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==
 
-"@urql/core@^1.15.1":
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/@urql/core/-/core-1.15.1.tgz#fa49909f2841d092796dd540cef6e9df89222560"
-  integrity sha512-a05ablx/aKNCUc9dEbx0GvE28UC0sJ1FmfsSfmJNqecYlYeb4XvSQW4FLVy0e/MjQeB9op/weiVIEw+za2ssGw==
+"@urql/core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@urql/core/-/core-2.0.0.tgz#b4936dd51fe84cb570506d9ee2579149689f7535"
+  integrity sha512-Qj24CG8ullqZZsYmjrSH0JhH+nY7kj8GbVbA9si3KUjlYs75A/MBQU3i97j6oWyGldDBapyis2CfaQeXKbv8rA==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.0"
     wonka "^4.0.14"
+
+"@urql/rescript@link:../..":
+  version "0.0.0"
+  uid ""
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -506,10 +510,10 @@ bs-fetch@^0.6.2:
   resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.6.2.tgz#37d982e9f79b9bc44c23e87ae78ccbee1f869adf"
   integrity sha512-VXEjp8kY3vHPckaoy3d96Bx0KYjJAPLNISBwfpwMN26K6DtuZYwI2HKhx7zeHBajz1bRArfx7O8OOLcdtujMvg==
 
-bs-platform@9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-9.0.1.tgz#069dae007aadb400963cec25c8349ea1f3f6cae0"
-  integrity sha512-RxUrwxVBCx9AiiyFIthZwfPn+tAn9noRHCb9xJK4Uw2deGxIytqyoWDepMbH35v7EpxX0OhfXL5RrjHTaXersA==
+bs-platform@9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-9.0.2.tgz#a6eac70eb8924a322556dacaccbfbc9b2a0d3a37"
+  integrity sha512-Ye9JqJ4Oa7mcjjoOVRYI8Uc2Cf8N7jQLWDcdUplY7996d/YErSR7WitmV7XnSwr4EvdrbwjEsg1NxNjUQv3ChA==
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -2590,10 +2594,6 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-"reason-urql@link:../..":
-  version "0.0.0"
-  uid ""
-
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
@@ -3225,12 +3225,12 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urql@~1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-1.11.2.tgz#dfc63734b26262cf4f143768f345b104094b32c0"
-  integrity sha512-1MIjOjZO5xgdqtcj9QdD2/JXpEVAl03vylaiSVm6QGqEbkBP9Zvb405QUJzCbVKH8bFoPxfcjvNAWwM8lekEMg==
+urql@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/urql/-/urql-2.0.1.tgz#16c024ab0340328001b0c400ebe1368887af3823"
+  integrity sha512-UTYLaMMw/N2iM2nHbcZ1XvN+opZxtWKwJaczV+MAco8buFpR3JR9CFrgKvx9p4uz+EayqQ69LZTWreJx+c196w==
   dependencies:
-    "@urql/core" "^1.15.1"
+    "@urql/core" "^2.0.0"
     wonka "^4.0.14"
 
 use@^3.1.0:

--- a/examples/5-subscription/bsconfig.json
+++ b/examples/5-subscription/bsconfig.json
@@ -19,12 +19,11 @@
   ],
   "suffix": ".bs.js",
   "bs-dependencies": [
-    "reason-urql",
+    "@urql/rescript",
     "@rescript/react",
     "wonka",
     "@reasonml-community/graphql-ppx"
   ],
-  "refmt": 3,
   "warnings": {
     "error": "+5"
   },

--- a/examples/5-subscription/package.json
+++ b/examples/5-subscription/package.json
@@ -1,7 +1,7 @@
 {
   "name": "5-subscription",
   "version": "0.1.0",
-  "description": "An example of how to use the Subscription component in reason-urql.",
+  "description": "An example of how to use the useSubscription hook in rescript-urql.",
   "main": "src/app/index.bs.js",
   "author": "Parker Ziegler <parker.ziegler@formidable.com>",
   "license": "MIT",
@@ -16,10 +16,10 @@
   "dependencies": {
     "@reasonml-community/graphql-ppx": "^1.0.1",
     "@rescript/react": "^0.10.1",
+    "@urql/rescript": "link:../../",
     "graphql": "^15.4.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "reason-urql": "link:../../",
     "urql": "^2.0.0"
   },
   "devDependencies": {

--- a/examples/5-subscription/public/index.html
+++ b/examples/5-subscription/public/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, minimum-scale=1"
     />
-    <title>reason-urql: useSubscription</title>
+    <title>rescript-urql: useSubscription</title>
     <style type="text/css">
       html {
         font-size: 10px;

--- a/examples/5-subscription/src/app/Circles.res
+++ b/examples/5-subscription/src/app/Circles.res
@@ -1,4 +1,4 @@
-open ReasonUrql
+open ReScriptUrql
 
 module SubscribeRandomInt = %graphql(`
   subscription subscribeNumbers {
@@ -24,7 +24,9 @@ let make = () => {
   | Fetching => <text> {"Loading"->React.string} </text>
   | Data(d)
   | PartialData(d, _) =>
-    d |> Array.to_list |> List.mapi((index, datum: SubscribeRandomInt.t) => {
+    d
+    |> Array.to_list
+    |> List.mapi((index, datum: SubscribeRandomInt.t) => {
       let cx = datum.newNumber->string_of_int
       let cy = (index === 0 ? datum.newNumber : d[index - 1].newNumber)->string_of_int
       <circle
@@ -35,7 +37,9 @@ let make = () => {
         fill="none"
         r={Util.getRandomInt(30) |> string_of_int}
       />
-    }) |> Array.of_list |> React.array
+    })
+    |> Array.of_list
+    |> React.array
   | Error(_e) => <text> {"Error"->React.string} </text>
   | Empty => <text> {"Not Found"->React.string} </text>
   }

--- a/examples/5-subscription/src/app/Squares.res
+++ b/examples/5-subscription/src/app/Squares.res
@@ -1,4 +1,4 @@
-open ReasonUrql
+open ReScriptUrql
 
 module SubscribeRandomFloat = %graphql(`
   subscription subscribeFloat {

--- a/examples/5-subscription/src/app/bindings/SubscriptionsTransportWS.res
+++ b/examples/5-subscription/src/app/bindings/SubscriptionsTransportWS.res
@@ -1,4 +1,4 @@
-open ReasonUrql
+open ReScriptUrql
 
 type subscriptionClientOptions = {
   timeout: option<int>,

--- a/examples/5-subscription/src/app/bindings/SubscriptionsTransportWS.resi
+++ b/examples/5-subscription/src/app/bindings/SubscriptionsTransportWS.resi
@@ -1,4 +1,4 @@
-open ReasonUrql
+open ReScriptUrql
 
 type subscriptionClientOptions = {
   timeout: option<int>,

--- a/examples/5-subscription/src/app/index.res
+++ b/examples/5-subscription/src/app/index.res
@@ -1,4 +1,4 @@
-open ReasonUrql
+open ReScriptUrql
 
 let subscriptionClient = SubscriptionsTransportWS.make(
   ~url="ws://localhost:4001/graphql",

--- a/examples/5-subscription/yarn.lock
+++ b/examples/5-subscription/yarn.lock
@@ -329,6 +329,10 @@
     "@graphql-typed-document-node/core" "^3.1.0"
     wonka "^4.0.14"
 
+"@urql/rescript@link:../..":
+  version "0.0.0"
+  uid ""
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -3167,10 +3171,6 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
-
-"reason-urql@link:../..":
-  version "0.0.0"
-  uid ""
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "rescript",
     "bucklescript",
     "graphql",
-    "urql"
+    "urql",
+    "react"
   ],
   "author": "Parker Ziegler <parker.ziegler@formidable.com>",
   "contributors": [

--- a/src/Client.res
+++ b/src/Client.res
@@ -206,7 +206,7 @@ type clientOptions<'fetchOptions, 'fetchImpl> = {
 external client: clientOptions<'fetchOptions, 'fetchImpl> => t = "Client"
 
 /* `make` is equivalent to urql's `createClient`.
- We opt to use `make` here to adhere to standards in the Reason community. */
+ We opt to use `make` here to adhere to standards in the ReScript community. */
 let make = (
   ~url,
   ~fetchOptions=?,
@@ -292,7 +292,7 @@ let executeQuery:
     )
 
     executeQueryJs(~client, ~query=req, ~opts=optsJs, ()) |> Wonka.map((. response) =>
-      Types.operationResultToReason(~response, ~parse=Query.parse)
+      Types.operationResultToReScript(~response, ~parse=Query.parse)
     )
   }
 
@@ -353,7 +353,7 @@ let executeMutation:
     )
 
     executeMutationJs(~client, ~mutation=req, ~opts=optsJs, ()) |> Wonka.map((. response) =>
-      Types.operationResultToReason(~response, ~parse=Mutation.parse)
+      Types.operationResultToReScript(~response, ~parse=Mutation.parse)
     )
   }
 
@@ -414,7 +414,7 @@ let executeSubscription:
     )
 
     executeSubscriptionJs(~client, ~subscription=req, ~opts=optsJs, ()) |> Wonka.map((. response) =>
-      Types.operationResultToReason(~response, ~parse=Subscription.parse)
+      Types.operationResultToReScript(~response, ~parse=Subscription.parse)
     )
   }
 

--- a/src/Types.res
+++ b/src/Types.res
@@ -160,10 +160,10 @@ module Hooks = {
     stale: bool,
   }
 
-  @ocaml.doc("
+  /*
    * A function for converting the response to an urql hook from its
    * JavaScript representation to a typed ReScript record.
-   ")
+   */
   let hookResponseToReScript:
     type dataJs data. (
       ~response: hookResponseJs<dataJs>,

--- a/src/Types.res
+++ b/src/Types.res
@@ -93,7 +93,10 @@ type operationResult<'data> = {
   stale: option<bool>,
 }
 
-let operationResultToReason = (~response: operationResultJs<'dataJs>, ~parse: 'dataJs => 'data) => {
+let operationResultToReScript = (
+  ~response: operationResultJs<'dataJs>,
+  ~parse: 'dataJs => 'data,
+) => {
   let {error, extensions, stale}: operationResultJs<'dataJs> = response
   let data = response.data->Js.Nullable.toOption->Belt.Option.map(parse)
 
@@ -159,9 +162,9 @@ module Hooks = {
 
   @ocaml.doc("
    * A function for converting the response to an urql hook from its
-   * JavaScript representation to a typed Reason record.
+   * JavaScript representation to a typed ReScript record.
    ")
-  let hookResponseToReason:
+  let hookResponseToReScript:
     type dataJs data. (
       ~response: hookResponseJs<dataJs>,
       ~parse: dataJs => data,

--- a/src/Types.resi
+++ b/src/Types.resi
@@ -82,7 +82,7 @@ type operationResult<'data> = {
   stale: option<bool>,
 }
 
-let operationResultToReason: (
+let operationResultToReScript: (
   ~response: operationResultJs<'dataJs>,
   ~parse: 'dataJs => 'data,
 ) => operationResult<'data>
@@ -138,7 +138,7 @@ module Hooks: {
     stale: bool,
   }
 
-  let hookResponseToReason: (
+  let hookResponseToReScript: (
     ~response: hookResponseJs<'dataJs>,
     ~parse: 'dataJs => 'data,
   ) => hookResponse<'data>

--- a/src/hooks/UseMutation.res
+++ b/src/hooks/UseMutation.res
@@ -42,7 +42,7 @@ let useMutation:
     let (stateJs, executeMutationJs) = useMutationJs(query)
 
     let state = React.useMemo2(
-      () => Types.Hooks.hookResponseToReason(~response=stateJs, ~parse),
+      () => Types.Hooks.hookResponseToReScript(~response=stateJs, ~parse),
       (stateJs, parse),
     )
 
@@ -79,7 +79,7 @@ let useMutation:
           ctx,
         )->{
           open Js.Promise
-          then_(response => Types.operationResultToReason(~response, ~parse)->resolve, _)
+          then_(response => Types.operationResultToReScript(~response, ~parse)->resolve, _)
         }
       },
       [executeMutationJs],

--- a/src/hooks/UseMutation.res
+++ b/src/hooks/UseMutation.res
@@ -28,9 +28,7 @@ type useMutationResponse<'variables, 'data> = (
 @module("urql")
 external useMutationJs: string => useMutationResponseJs<'dataJs> = "useMutation"
 
-@ocaml.doc("
- * The useMutation hook.
- ")
+// The useMutation hook.
 let useMutation:
   type data variables. (
     ~mutation: module(Types.Operation with type t = data and type t_variables = variables),

--- a/src/hooks/UseQuery.res
+++ b/src/hooks/UseQuery.res
@@ -99,7 +99,7 @@ let useQuery:
     let (stateJs, executeQueryJs) = useQueryJs(args)
 
     let state = React.useMemo2(
-      () => Types.Hooks.hookResponseToReason(~response=stateJs, ~parse),
+      () => Types.Hooks.hookResponseToReScript(~response=stateJs, ~parse),
       (stateJs, parse),
     )
 

--- a/src/hooks/UseSubscription.res
+++ b/src/hooks/UseSubscription.res
@@ -1,8 +1,8 @@
-@@ocaml.doc("
-* The handler type used to type the optional accumulator function
-* returned by useSubscription. handler is a GADT used to support
-* proper type inference for useSubscription.
-")
+/*
+ * The handler type used to type the optional accumulator function
+ * returned by useSubscription. handler is a GADT used to support
+ * proper type inference for useSubscription.
+ */
 type rec handler<'acc, 'response, 'ret> =
   | Handler((option<'acc>, 'response) => 'acc): handler<'acc, 'response, 'acc>
   | NoHandler: handler<'response, 'response, 'response>

--- a/src/hooks/UseSubscription.res
+++ b/src/hooks/UseSubscription.res
@@ -36,7 +36,7 @@ type executeSubscription = (
 
 type useSubscriptionResponse<'response> = (Types.Hooks.hookResponse<'response>, executeSubscription)
 
-let subscriptionResponseToReason = (response: Types.Hooks.hookResponseJs<'ret>) => {
+let subscriptionResponseToReScript = (response: Types.Hooks.hookResponseJs<'ret>) => {
   let {Types.Hooks.operation: operation, fetching, error, extensions, stale} = response
 
   let data = response.data->Js.Nullable.toOption
@@ -124,7 +124,7 @@ let useSubscription = (
 
   let (responseJs, executeSubscriptionJs) = useSubscriptionJs(args, Some(h))
 
-  let state = React.useMemo1(() => subscriptionResponseToReason(responseJs), [responseJs])
+  let state = React.useMemo1(() => subscriptionResponseToReScript(responseJs), [responseJs])
 
   let executeSubscription = React.useMemo1(
     (


### PR DESCRIPTION
Fix #249 

This PR makes all changes necessary to support the repo naming migration to `rescript-urql`! This includes:

- Updating internal function names that reference Reason.
- Updating the repo name in all documentation.
- Updating `bsconfig.json` in the root and all examples to ensure the root module is reference-able as `ReScriptUrql`.
- Updating installation instructions and examples to reference `@urql/rescript`.